### PR TITLE
Replace macros with TIOGA_ prefix to avoid conflicts

### DIFF
--- a/src/ADT.C
+++ b/src/ADT.C
@@ -55,11 +55,11 @@ void ADT::buildADT(int d, int nelements,double *elementBbox)
   /*
    * Allocate arrays in the class
    */
-  if (adtExtents) free(adtExtents);
+  if (adtExtents) TIOGA_FREE(adtExtents);
   adtExtents=(double *) malloc(sizeof(double)*ndim);
-  if (adtIntegers) free(adtIntegers);
+  if (adtIntegers) TIOGA_FREE(adtIntegers);
   adtIntegers=(int *) malloc(sizeof(int)*4*nelem);
-  if (adtReals) free(adtReals);
+  if (adtReals) TIOGA_FREE(adtReals);
   adtReals=(double *) malloc(sizeof(double)*nelem*ndim);
   /*
    * Determine extent of elements
@@ -76,12 +76,12 @@ void ADT::buildADT(int d, int nelements,double *elementBbox)
      for(i=0;i<ndim/2;i++)
        {
 	 i2=2*i;
-	 adtExtents[i2]=MIN(adtExtents[i2],coord[j6+i]);
+	 adtExtents[i2]=TIOGA_MIN(adtExtents[i2],coord[j6+i]);
        }
        for(i=0;i<ndim/2;i++)
        {
 	 i2=2*i+1;
-	 adtExtents[i2]=MAX(adtExtents[i2],coord[j6+i+ndim/2]);
+	 adtExtents[i2]=TIOGA_MAX(adtExtents[i2],coord[j6+i+ndim/2]);
        }
    }
   //
@@ -130,6 +130,6 @@ void ADT::buildADT(int d, int nelements,double *elementBbox)
   // }
   //fclose(fp);
   //fclose(fp1);
-  free(elementsAvailable);
-  free(adtWork);
+  TIOGA_FREE(elementsAvailable);
+  TIOGA_FREE(adtWork);
 }

--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -70,8 +70,8 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
        for(i=0;i<(*nints)*3;i++) tmpint[i]=(*intData)[i];
        for(i=0;i<(*nreals);i++) tmpreal[i]=(*realData)[i];
        //
-       free((*intData));
-       free((*realData)); // didnt free this before ??
+       TIOGA_FREE((*intData));
+       TIOGA_FREE((*realData)); // didnt free this before ??
        //  
       }
       (*nints)+=interpCount;
@@ -81,8 +81,8 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
       if (nintold > 0) {
        for(i=0;i<nintold*3;i++) (*intData)[i]=tmpint[i];
        for(i=0;i<nrealold;i++) (*realData)[i]=tmpreal[i];      
-       free(tmpint);
-       free(tmpreal);
+       TIOGA_FREE(tmpint);
+       TIOGA_FREE(tmpreal);
       }
       listptr=interpList;
       icount=3*nintold;
@@ -113,9 +113,9 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 	    (*realData)[dcount++]=qq[n];
 	  listptr=listptr->next;
 	}
-      free(xtmp);
-      free(index);
-      free(qq);
+      TIOGA_FREE(xtmp);
+      TIOGA_FREE(index);
+      TIOGA_FREE(qq);
     }
 }
 
@@ -161,7 +161,7 @@ void CartBlock::clearLists(void)
   int i;
   if (donorList) {
   for(i=0;i<ndof;i++) { deallocateLinkList(donorList[i]); donorList[i]=NULL;}
-  free(donorList);
+  TIOGA_FREE(donorList);
   }
   deallocateLinkList4(interpList);
   interpList=NULL;
@@ -230,7 +230,7 @@ void CartBlock::insertInInterpList(int procid,int remoteid,int remoteblockid,dou
   listptr->inode[1]=ix[1];
   listptr->inode[2]=ix[2];
   donor_frac(&pdegree,rst,&(listptr->nweights),(listptr->weights));  
-  free(rst);
+  TIOGA_FREE(rst);
 }
   
 void CartBlock::insertInDonorList(int senderid,int index,int meshtagdonor,int remoteid,int remoteblockid, double cellRes)
@@ -556,8 +556,8 @@ void CartBlock::writeCellFile(int bid)
 	{
 	  ibindex=(k+nf)*(dims[1]+2*nf)*(dims[0]+2*nf)+
 	    (j+nf)*(dims[0]+2*nf)+(i+nf);
-          ibmin=MIN(ibmin,ibl[ibindex]);
-          ibmax=MAX(ibmax,ibl[ibindex]);
+          ibmin=TIOGA_MIN(ibmin,ibl[ibindex]);
+          ibmax=TIOGA_MAX(ibmax,ibl[ibindex]);
 	  fprintf(fp,"%d\n", ibl[ibindex]);
 	}
 

--- a/src/CartBlock.h
+++ b/src/CartBlock.h
@@ -17,12 +17,12 @@
 // You should have received a copy of the GNU Lesser General Public
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-//#include "codetypes.h"
 
 #ifndef CARTBLOCK_H
 #define CARTBLOCK_H
 
 #include <cstdlib>
+#include "codetypes.h"
 
 struct INTERPLIST2;
 struct DONORLIST;

--- a/src/CartGrid.C
+++ b/src/CartGrid.C
@@ -90,8 +90,8 @@ void CartGrid::preprocess(void)
   for (i=0;i<ngrids;i++)
     {
       for(n=0;n<3;n++)
-	xlosup[n]=Min(xlosup[n],xlo[3*i+n]);
-      maxlevel=Max(maxlevel,level_num[i]);
+	xlosup[n]=TIOGA_Min(xlosup[n],xlo[3*i+n]);
+      maxlevel=TIOGA_Max(maxlevel,level_num[i]);
     }
     maxlevel++;
   lcount=(int *)malloc(sizeof(int)*maxlevel);

--- a/src/MeshBlock.C
+++ b/src/MeshBlock.C
@@ -67,7 +67,7 @@ void MeshBlock::preprocess(void)
   //
   // find oriented bounding boxes
   //
-  if (obb) free(obb);
+  if (obb) TIOGA_FREE(obb);
   obb=(OBB *) malloc(sizeof(OBB));
   findOBB(x,obb->xc,obb->dxc,obb->vec,nnodes);
   tagBoundary();
@@ -93,8 +93,8 @@ void MeshBlock::tagBoundary(void)
   // initialized, cellRes would be NULL in this case
   //
 
-      if(cellRes) free(cellRes);
-      if(nodeRes) free(nodeRes);
+      if(cellRes) TIOGA_FREE(cellRes);
+      if(nodeRes) TIOGA_FREE(nodeRes);
     
       //
       cellRes=(double *) malloc(sizeof(double)*ncells);
@@ -242,9 +242,9 @@ void MeshBlock::tagBoundary(void)
 	  }
 	for(i=0;i<nnodes;i++) iextmp[i]=iextmp1[i];	
       }
-      free(iflag);
-      free(iextmp);
-      free(iextmp1);
+      TIOGA_FREE(iflag);
+      TIOGA_FREE(iextmp);
+      TIOGA_FREE(iextmp1);
 }
 
 void MeshBlock::writeGridFile(int bid)
@@ -565,8 +565,8 @@ void MeshBlock::getWallBounds(int *mtag,int *existWall, double wbox[6])
       i3=3*inode;
       for(j=0;j<3;j++)
 	{
-	  wbox[j]=MIN(wbox[j],x[i3+j]);
-	  wbox[j+3]=MAX(wbox[j+3],x[i3+j]);
+	  wbox[j]=TIOGA_MIN(wbox[j],x[i3+j]);
+	  wbox[j+3]=TIOGA_MAX(wbox[j+3],x[i3+j]);
 	}
     }
   
@@ -653,14 +653,14 @@ void MeshBlock::markWallBoundary(int *sam,int nx[3],double extents[6])
 		    {
 		      xv=x[i3+k];
 		      iv=floor((xv-extents[k])/ds[k]);
-		      imin[k]=MIN(imin[k],iv);
-		      imax[k]=MAX(imax[k],iv);
+		      imin[k]=TIOGA_MIN(imin[k],iv);
+		      imax[k]=TIOGA_MAX(imax[k],iv);
 		    }
 		}
 	     for(j=0;j<3;j++)
               {
-	       imin[j]=MAX(imin[j],0);
-               imax[j]=MIN(imax[j],nx[j]-1);
+	       imin[j]=TIOGA_MAX(imin[j],0);
+               imax[j]=TIOGA_MIN(imax[j],nx[j]-1);
               }
 	      //
 	      // mark sam to 1
@@ -676,8 +676,8 @@ void MeshBlock::markWallBoundary(int *sam,int nx[3],double extents[6])
 	  m++;
 	}
      }
-   free(iflag);
-   free(inode);
+   TIOGA_FREE(iflag);
+   TIOGA_FREE(inode);
 }
 
 void MeshBlock::getReducedOBB(OBB *obc,double *realData) 
@@ -707,8 +707,8 @@ void MeshBlock::getReducedOBB(OBB *obc,double *realData)
 	      for(j=0;j<3;j++)
 		for(k=0;k<3;k++)
 		  xd[j]+=(x[i3+k]-obc->xc[k])*obc->vec[j][k];
-	      for(j=0;j<3;j++) bbox[j]=MIN(bbox[j],xd[j]);
-	      for(j=0;j<3;j++) bbox[j+3]=MAX(bbox[j+3],xd[j]);
+	      for(j=0;j<3;j++) bbox[j]=TIOGA_MIN(bbox[j],xd[j]);
+	      for(j=0;j<3;j++) bbox[j+3]=TIOGA_MAX(bbox[j+3],xd[j]);
 	    }
 	  iflag=0;
 	  for(j=0;j<3;j++) iflag=(iflag || (bbox[j] > obc->dxc[j]));
@@ -723,8 +723,8 @@ void MeshBlock::getReducedOBB(OBB *obc,double *realData)
 	      for(j=0;j<3;j++)
 		for(k=0;k<3;k++)
 		  xd[j]+=(x[i3+k]-obb->xc[k])*obb->vec[j][k];
-	      for(j=0;j<3;j++) realData[j]=MIN(realData[j],xd[j]);
-	      for(j=0;j<3;j++) realData[j+3]=MAX(realData[j+3],xd[j]);
+	      for(j=0;j<3;j++) realData[j]=TIOGA_MIN(realData[j],xd[j]);
+	      for(j=0;j<3;j++) realData[j+3]=TIOGA_MAX(realData[j+3],xd[j]);
 	    }
 	}
     }
@@ -785,7 +785,7 @@ void MeshBlock::getQueryPoints(OBB *obc,
       (*realData)[m++]=nodeRes[inode[i]];
     }
   //
-  free(inode);
+  TIOGA_FREE(inode);
 }  
   
 void MeshBlock::writeOBB(int bid)
@@ -840,62 +840,62 @@ MeshBlock::~MeshBlock()
   // free all data that is owned by this MeshBlock
   // i.e not the pointers of the external code.
   //
-  if (cellRes) free(cellRes);
-  if (nodeRes) free(nodeRes);
-  if (elementBbox) free(elementBbox);
-  if (elementList) free(elementList);
+  if (cellRes) TIOGA_FREE(cellRes);
+  if (nodeRes) TIOGA_FREE(nodeRes);
+  if (elementBbox) TIOGA_FREE(elementBbox);
+  if (elementList) TIOGA_FREE(elementList);
   if (adt) delete[] adt;
   if (donorList) {
     for(i=0;i<nnodes;i++) deallocateLinkList(donorList[i]);
-    free(donorList);
+    TIOGA_FREE(donorList);
   }
   if (interpList) {
     for(i=0;i<interpListSize;i++)
       {
-	if (interpList[i].inode) free(interpList[i].inode);
-	if (interpList[i].weights) free(interpList[i].weights);
+	if (interpList[i].inode) TIOGA_FREE(interpList[i].inode);
+	if (interpList[i].weights) TIOGA_FREE(interpList[i].weights);
       }
-    free(interpList);
+    TIOGA_FREE(interpList);
   }
   if (interpList2) {
     for(i=0;i<interp2ListSize;i++)
       {
-	if (interpList2[i].inode) free(interpList2[i].inode);
-	if (interpList2[i].weights) free(interpList2[i].weights);
+	if (interpList2[i].inode) TIOGA_FREE(interpList2[i].inode);
+	if (interpList2[i].weights) TIOGA_FREE(interpList2[i].weights);
       }
-    free(interpList2);
+    TIOGA_FREE(interpList2);
   }
   if (interpListCart) {
     for(i=0;i<interpListCartSize;i++)
       {
-        if (interpListCart[i].inode) free(interpListCart[i].inode);
- 	if (interpListCart[i].weights) free(interpListCart[i].weights);
+        if (interpListCart[i].inode) TIOGA_FREE(interpListCart[i].inode);
+ 	if (interpListCart[i].weights) TIOGA_FREE(interpListCart[i].weights);
       }
-    free(interpListCart);
+    TIOGA_FREE(interpListCart);
   }
   // For nalu-wind API the iblank_cell array is managed on the nalu side
   // if (!ihigh) {
-  //  if (iblank_cell) free(iblank_cell);
+  //  if (iblank_cell) TIOGA_FREE(iblank_cell);
   // }
-  if (obb) free(obb);
-  if (isearch) free(isearch);
-  if (xsearch) free(xsearch);
-  if (res_search) free(res_search);
-  if (xtag) free(xtag);
-  if (rst) free(rst);
-  if (interp2donor) free(interp2donor);
+  if (obb) TIOGA_FREE(obb);
+  if (isearch) TIOGA_FREE(isearch);
+  if (xsearch) TIOGA_FREE(xsearch);
+  if (res_search) TIOGA_FREE(res_search);
+  if (xtag) TIOGA_FREE(xtag);
+  if (rst) TIOGA_FREE(rst);
+  if (interp2donor) TIOGA_FREE(interp2donor);
   if (cancelList) deallocateLinkList2(cancelList);
-  if (ctag) free(ctag);
-  if (pointsPerCell) free(pointsPerCell);
-  if (rxyz) free(rxyz);
-  if (picked) free(picked);
-  if (rxyzCart) free(rxyzCart);
-  if (donorIdCart) free(donorIdCart);
-  if (pickedCart) free(pickedCart);
-  if (ctag_cart) free(ctag_cart);
+  if (ctag) TIOGA_FREE(ctag);
+  if (pointsPerCell) TIOGA_FREE(pointsPerCell);
+  if (rxyz) TIOGA_FREE(rxyz);
+  if (picked) TIOGA_FREE(picked);
+  if (rxyzCart) TIOGA_FREE(rxyzCart);
+  if (donorIdCart) TIOGA_FREE(donorIdCart);
+  if (pickedCart) TIOGA_FREE(pickedCart);
+  if (ctag_cart) TIOGA_FREE(ctag_cart);
 
-  if (tagsearch) free(tagsearch);
-  if (donorId) free(donorId);
+  if (tagsearch) TIOGA_FREE(tagsearch);
+  if (donorId) TIOGA_FREE(donorId);
   // need to add code here for other objects as and
   // when they become part of MeshBlock object  
 };

--- a/src/MeshBlock.h
+++ b/src/MeshBlock.h
@@ -24,7 +24,7 @@
 #include <vector>
 #include <stdint.h>
 
-//#include "codetypes.h"
+#include "codetypes.h"
 #include "ADT.h"
 // forward declare to instantiate one of the methods
 class parallelComm;

--- a/src/bookKeeping.C
+++ b/src/bookKeeping.C
@@ -67,8 +67,8 @@ void MeshBlock::getDonorPacket(PACKET *sndPack, int nsend)
           sndPack[k].realData[dcount[k]++]=cellRes[donorId[i]];  // donor resolution
         }
     }
-  free(icount);
-  free(dcount);
+  TIOGA_FREE(icount);
+  TIOGA_FREE(dcount);
 }
 
 void MeshBlock::getMBDonorPktSizes
@@ -118,7 +118,7 @@ void MeshBlock::initializeDonorList(void)
 	deallocateLinkList(donorList[i]);
 	//printf("\n\t Deallocate (nnodes) i: %d %d ",nnodes,i);
        }
-      free(donorList);
+      TIOGA_FREE(donorList);
     }
 
   donorListLength = nnodes;
@@ -205,7 +205,7 @@ void MeshBlock::processDonors(HOLEMAP *holemap, int nmesh, int **donorRecords,do
                TRACEI(temp->donorData[1]);
                TRACEI(temp->donorData[2]);
               }
-              nodeRes[i]=MAX(nodeRes[i],temp->receptorRes);
+              nodeRes[i]=TIOGA_MAX(nodeRes[i],temp->receptorRes);
 	      temp=temp->next;
 	    }
 	  for(j=0;j<nmesh;j++)
@@ -268,8 +268,8 @@ void MeshBlock::processDonors(HOLEMAP *holemap, int nmesh, int **donorRecords,do
   }
   for(i=0;i<nnodes;i++)
      if (mtag1[i] && iblank[i]) nodeRes[i]=BIGVALUE;
-  free(mtag);
-  free(mtag1);
+  TIOGA_FREE(mtag);
+  TIOGA_FREE(mtag1);
   //
   // now find fringes
   //
@@ -351,7 +351,7 @@ void MeshBlock::processDonors(HOLEMAP *holemap, int nmesh, int **donorRecords,do
   //
   // release local memory
   //
-  free(iflag);
+  TIOGA_FREE(iflag);
 }
 
 void MeshBlock::initializeInterpList(int ninterp_input)
@@ -361,10 +361,10 @@ void MeshBlock::initializeInterpList(int ninterp_input)
     //for(i=0;i<ninterp;i++)
     for(i=0;i<interpListSize;i++)
       {
-	if (interpList[i].inode) free(interpList[i].inode);
-	if (interpList[i].weights) free(interpList[i].weights);
+	if (interpList[i].inode) TIOGA_FREE(interpList[i].inode);
+	if (interpList[i].weights) TIOGA_FREE(interpList[i].weights);
       }
-    free(interpList);
+    TIOGA_FREE(interpList);
   }
   ninterp=ninterp_input;   
   interpListSize=ninterp_input;
@@ -376,7 +376,7 @@ void MeshBlock::initializeInterpList(int ninterp_input)
   if (cancelList) deallocateLinkList2(cancelList);
   cancelList=NULL;
   ncancel=0;
-  if (interp2donor) free(interp2donor);
+  if (interp2donor) TIOGA_FREE(interp2donor);
   interp2donor=(int *)malloc(sizeof(int)*nsearch);
   for(i=0;i<nsearch;i++) interp2donor[i]=-1;
     
@@ -572,7 +572,7 @@ void MeshBlock::resetCoincident(void)
     {
       iptr=interp2donor[i];
       if (iptr > -1) {
-        ireset[xtag[i]]=MIN(ireset[xtag[i]],interpList[iptr].cancel);
+        ireset[xtag[i]]=TIOGA_MIN(ireset[xtag[i]],interpList[iptr].cancel);
       }
     }	
   for(i=0;i<nsearch;i++)
@@ -584,7 +584,7 @@ void MeshBlock::resetCoincident(void)
 	}
       }
     }
-  free(ireset);
+  TIOGA_FREE(ireset);
 }
 void MeshBlock::getInterpData(int *nrecords, int **intData)
 {
@@ -611,7 +611,7 @@ void MeshBlock::clearIblanks(void)
   if (iblank_reduced) {
    for(i=0;i<nnodes;i++)
      if (iblank_reduced[i]==0) iblank[i]=0;
-   free(iblank_reduced);
+   TIOGA_FREE(iblank_reduced);
   }
 }
 
@@ -645,7 +645,7 @@ void MeshBlock::reduce_fringes(void)
   int verbose,iter;
   INTEGERLIST *clist;
   //
-  if (iblank_reduced) free(iblank_reduced);
+  if (iblank_reduced) TIOGA_FREE(iblank_reduced);
   iblank_reduced=(int *)malloc(sizeof(int)*nnodes);
   for(int i=0;i< nnodes;i++) iblank_reduced[i]=iblank[i] > 0 ? iblank[i]:0;
   ibltmp=(int *)malloc(sizeof(int)*nnodes);
@@ -747,7 +747,7 @@ void MeshBlock::reduce_fringes(void)
   //       }
   //   }
   // TRACEI(norph);
-  free(ibltmp);
+  TIOGA_FREE(ibltmp);
 }
 
 

--- a/src/buildADTrecursion.c
+++ b/src/buildADTrecursion.c
@@ -74,8 +74,8 @@ void buildADTrecursion(double *coord,double *adtReals,double *adtWork,int *adtIn
 	  jj=ndim*elementsAvailable[i]+j;
 	  jjp=jj+nd;
 	  //
-	  adtReals[ii]=MIN(adtReals[ii],coord[jj]);
-	  adtReals[iip]=MAX(adtReals[iip],coord[jjp]);
+	  adtReals[ii]=TIOGA_MIN(adtReals[ii],coord[jj]);
+	  adtReals[iip]=TIOGA_MAX(adtReals[iip],coord[jjp]);
 	}
     //
     // specify that the new element is the child of parent

--- a/src/cartOps.C
+++ b/src/cartOps.C
@@ -64,7 +64,7 @@ void MeshBlock::getUnresolvedMandatoryReceptors(void)
   int inode[8];
   int *iflag;
   iflag=(int *) malloc(sizeof(int) *ncells);
-  if (pickedCart !=NULL) free(pickedCart);
+  if (pickedCart !=NULL) TIOGA_FREE(pickedCart);
   pickedCart=(int *) malloc(sizeof(int)*nnodes);
 
   for(i=0;i<ncells;i++) iflag[i]=0;
@@ -92,7 +92,7 @@ void MeshBlock::getUnresolvedMandatoryReceptors(void)
 	}
     }
   //
-  if (ctag_cart!=NULL) free(ctag_cart);
+  if (ctag_cart!=NULL) TIOGA_FREE(ctag_cart);
   ctag_cart=(int *)malloc(sizeof(int)*ncells);
   nreceptorCellsCart=0;
   for(i=0;i<ncells;i++)
@@ -100,7 +100,7 @@ void MeshBlock::getUnresolvedMandatoryReceptors(void)
   //
   if (ihigh) 
     {
-      if (pointsPerCell!=NULL) free(pointsPerCell);
+      if (pointsPerCell!=NULL) TIOGA_FREE(pointsPerCell);
       pointsPerCell=(int *)malloc(sizeof(int)*nreceptorCellsCart);
       //
       maxPointsPerCell=0;
@@ -110,11 +110,11 @@ void MeshBlock::getUnresolvedMandatoryReceptors(void)
 	{
 	  get_nodes_per_cell(&(ctag_cart[i]),&(pointsPerCell[i]));
 	  ntotalPointsCart+=pointsPerCell[i];
-	  maxPointsPerCell=MAX(maxPointsPerCell,pointsPerCell[i]);
+	  maxPointsPerCell=TIOGA_MAX(maxPointsPerCell,pointsPerCell[i]);
       }
       //
-      if (rxyzCart !=NULL) free(rxyzCart);
-      if (donorIdCart !=NULL) free(donorIdCart);
+      if (rxyzCart !=NULL) TIOGA_FREE(rxyzCart);
+      if (donorIdCart !=NULL) TIOGA_FREE(donorIdCart);
       //printf("getInternalNodes : %d %d\n",myid,ntotalPoints);
       rxyzCart=(double *)malloc(sizeof(double)*ntotalPointsCart*3);
       donorIdCart=(int *)malloc(sizeof(int)*ntotalPointsCart);
@@ -136,8 +136,8 @@ void MeshBlock::getUnresolvedMandatoryReceptors(void)
 	      ntotalPointsCart++;
 	    }
 	}
-      if (rxyzCart !=NULL) free(rxyzCart);
-      if (donorIdCart !=NULL) free(donorIdCart);
+      if (rxyzCart !=NULL) TIOGA_FREE(rxyzCart);
+      if (donorIdCart !=NULL) TIOGA_FREE(donorIdCart);
       rxyzCart=(double *)malloc(sizeof(double)*ntotalPointsCart*3);
       donorIdCart=(int *)malloc(sizeof(int)*ntotalPointsCart);
       m=0;
@@ -149,7 +149,7 @@ void MeshBlock::getUnresolvedMandatoryReceptors(void)
 	      rxyzCart[m++]=x[i3+j];
 	  }
     }
- free(iflag);
+ TIOGA_FREE(iflag);
 }
 
 void MeshBlock::writeOBB2(OBB * obc, int bid)
@@ -210,10 +210,10 @@ void MeshBlock::findInterpListCart(void)
     {
       for(i=0;i<interpListCartSize;i++)
 	{
-	  if (interpListCart[i].inode) free(interpListCart[i].inode);
-	  if (interpListCart[i].weights) free(interpListCart[i].weights);
+	  if (interpListCart[i].inode) TIOGA_FREE(interpListCart[i].inode);
+	  if (interpListCart[i].weights) TIOGA_FREE(interpListCart[i].weights);
 	}
-      free(interpListCart);
+      TIOGA_FREE(interpListCart);
       interpListCartSize=0;
     }
   for(irecord=0;irecord<nsearch;irecord++)
@@ -315,8 +315,8 @@ void MeshBlock::getInterpolatedSolutionAMR(int *nints,int *nreals,int **intData,
      for(i=0;i<(*nints)*3;i++) tmpint[i]=(*intData)[i];
      for(i=0;i<(*nreals);i++) tmpreal[i]=(*realData)[i];
      //
-     free((*intData));
-     free((*realData)); // didnt free this before ??
+     TIOGA_FREE((*intData));
+     TIOGA_FREE((*realData)); // didnt free this before ??
      //
    }
    (*nints)+=interpCount;
@@ -327,8 +327,8 @@ void MeshBlock::getInterpolatedSolutionAMR(int *nints,int *nreals,int **intData,
     {
       for(i=0;i<nintold*3;i++) (*intData)[i]=tmpint[i];
       for(i=0;i<nrealold;i++) (*realData)[i]=tmpreal[i];
-      free(tmpint);
-      free(tmpreal);
+      TIOGA_FREE(tmpint);
+      TIOGA_FREE(tmpreal);
    }
   //
   icount=3*nintold;
@@ -431,5 +431,5 @@ void MeshBlock::getInterpolatedSolutionAMR(int *nints,int *nreals,int **intData,
 	    }
 	}
     }
-  if (qq) free(qq);
+  if (qq) TIOGA_FREE(qq);
 }

--- a/src/codetypes.h
+++ b/src/codetypes.h
@@ -59,9 +59,9 @@
 /*==================================================================*/
 # define TRACEI(x)  printf("#tioga:\t"#x" =%d\n",x);
 # define TRACED(x)  printf("#tioga:\t"#x" =%.16e\n",x);
-# define MIN(x,y)  (x) < (y) ? (x) : (y)
-# define MAX(x,y)  (x) > (y) ? (x) : (y)
-# define free(a1)  {free(a1);a1=NULL;}
+# define TIOGA_MIN(x,y)  (x) < (y) ? (x) : (y)
+# define TIOGA_MAX(x,y)  (x) > (y) ? (x) : (y)
+# define TIOGA_FREE(a1)  {free(a1);a1=NULL;}
 // # define debug(x,y)  printf("#tioga:\t"#x"=%d,"#y"=%d\n",x,y);
 // # define stdwrite(x) if (myid==0) printf("#tioga:\t"#x"\n");
 // # define dstr(x) printf("#tioga:\t"#x"\n");
@@ -70,8 +70,8 @@
 /*  Numerical Tools                                                   */
 /*====================================================================*/
 // #define Sign(a1,a2) (((a2) < ZERO)? - fabs(a1): fabs(a1))
-#define Max(a1,a2) (((a1) >= (a2))? (a1): (a2))
-#define Min(a1,a2) (((a1) <= (a2))? (a1): (a2))
+#define TIOGA_Max(a1,a2) (((a1) >= (a2))? (a1): (a2))
+#define TIOGA_Min(a1,a2) (((a1) <= (a2))? (a1): (a2))
 // #define Abs(aa) (((aa) >= 0)? (aa): -(aa))
 // #define Round(aa) (int) ((fabs((aa) - floor(aa)) >= HALF)? ceil(aa): floor(aa))
 // #define swap(a,b) { a=a+b;b=a-b;a=a-b;}

--- a/src/exchangeAMRDonors.C
+++ b/src/exchangeAMRDonors.C
@@ -158,7 +158,7 @@ void tioga::exchangeAMRDonors(void)
   //for(i=0;i<nsend;i++)
   //  printf("intcount/intcount=%d %d\n",sndPack[i].nreals,realcount[i]);
   //}
-  free(realcount);
+  TIOGA_FREE(realcount);
   //
   // exchange data
   //
@@ -222,7 +222,7 @@ void tioga::exchangeAMRDonors(void)
   for(i=0;i<ncart;i++) 
     {
       //TRACEI(i);
-      if (cancelledData) free(cancelledData);
+      if (cancelledData) TIOGA_FREE(cancelledData);
       cancelledData=NULL;
       ncancel=bcount[i];
       if (ncancel > 0) {
@@ -274,16 +274,16 @@ void tioga::exchangeAMRDonors(void)
   //
   for(int ib=0;ib<nblocks;ib++)
    mblocks[ib]->findInterpListCart();
-  if (cancelledData) free(cancelledData);
+  if (cancelledData) TIOGA_FREE(cancelledData);
   //fclose(fp);
-  free(bcount);
-  free(intcount);
-  free(sndMapAll);
-  free(rcvMapAll);
-  free(imap);
-  free(icount);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(bcount);
+  TIOGA_FREE(intcount);
+  TIOGA_FREE(sndMapAll);
+  TIOGA_FREE(rcvMapAll);
+  TIOGA_FREE(imap);
+  TIOGA_FREE(icount);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
 }
 void tioga::checkComm(void)
 {
@@ -320,9 +320,9 @@ void tioga::checkComm(void)
   //
   pc_cart->sendRecvPackets(sndPack,rcvPack);
   pc_cart->clearPackets2(sndPack,rcvPack);
-  free(sndMap);
-  free(rcvMap);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(sndMap);
+  TIOGA_FREE(rcvMap);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
   printf("checkComm complete in %d\n",myid);
 }

--- a/src/exchangeBoxes.C
+++ b/src/exchangeBoxes.C
@@ -228,7 +228,7 @@ void tioga::exchangeBoxes(void)
   pc->setMap(nsend,nrecv,sndMap,rcvMap);
 
 
-  // if (obblist) free(obblist);
+  // if (obblist) TIOGA_FREE(obblist);
   // obblist = (OBB*) malloc(sizeof(OBB) * intersectIDs.size());
   intBoxMap.clear();
   ibsPerProc.clear();
@@ -311,8 +311,8 @@ void tioga::exchangeBoxes(void)
   //
   // Free local memory
   //
-  free(sndMap);
-  free(rcvMap);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(sndMap);
+  TIOGA_FREE(rcvMap);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
 }

--- a/src/exchangeDonors.C
+++ b/src/exchangeDonors.C
@@ -188,7 +188,7 @@ void tioga::exchangeDonors(void)
   //
   for (int i=0; i<nblocks; i++) {
     if (donorRecords[i]) {
-      free(donorRecords[i]);
+      TIOGA_FREE(donorRecords[i]);
       donorRecords[i] = NULL;
     }
     nrecords[i] = 0;
@@ -240,7 +240,7 @@ void tioga::exchangeDonors(void)
   //
   for (int i=0; i<nblocks; i++) {
     if (donorRecords[i]) {
-      free(donorRecords[i]);
+      TIOGA_FREE(donorRecords[i]);
       donorRecords[i] = NULL;
     }
     nrecords[i] = 0;    
@@ -283,20 +283,20 @@ void tioga::exchangeDonors(void)
       }
   }
   pc->clearPackets(sndPack,rcvPack);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
   
   if (donorRecords) {
     for (int i=0; i<nblocks; i++) {
-      if (donorRecords[i]) free(donorRecords[i]);
+      if (donorRecords[i]) TIOGA_FREE(donorRecords[i]);
     }
-    free(donorRecords);
+    TIOGA_FREE(donorRecords);
   }
   if (receptorResolution) {
     for (int i=0; i<nblocks; i++) {
-      if (receptorResolution[i]) free(receptorResolution[i]);
+      if (receptorResolution[i]) TIOGA_FREE(receptorResolution[i]);
     }
-    free(receptorResolution);
+    TIOGA_FREE(receptorResolution);
   }   
 }
   

--- a/src/exchangeSearchData.C
+++ b/src/exchangeSearchData.C
@@ -118,28 +118,28 @@ void tioga::exchangeSearchData(int at_points)
     mb->nsearch = 0;
 
     if (mb->xsearch) {
-      free(mb->xsearch);
+      TIOGA_FREE(mb->xsearch);
       mb->xsearch=NULL;
     }
     if (mb->isearch) {
-      free(mb->isearch);
+      TIOGA_FREE(mb->isearch);
       mb->isearch=NULL;
     }
     if (mb->tagsearch) {
-      free(mb->tagsearch);
+      TIOGA_FREE(mb->tagsearch);
       mb->tagsearch=NULL;
     }
     if (mb->donorId) {
-      free(mb->donorId);
+      TIOGA_FREE(mb->donorId);
       mb->donorId=NULL;
     }
     if (mb->res_search) {
-      free(mb->res_search);
+      TIOGA_FREE(mb->res_search);
       mb->res_search=NULL;
     }
    if (at_points==1) {
      if (mb->rst) {
-       free(mb->rst);
+       TIOGA_FREE(mb->rst);
        mb->rst=NULL;
      }
     }
@@ -219,20 +219,20 @@ void tioga::exchangeSearchData(int at_points)
   }
 
   pc->clearPackets(sndPack, rcvPack);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
   // printf("%d %d\n",myid,mb->nsearch);
 
   if (int_data) {
     for (int i=0; i<nobb; i++) {
-      if (int_data[i]) free(int_data[i]);
+      if (int_data[i]) TIOGA_FREE(int_data[i]);
     }
-    free(int_data);
+    TIOGA_FREE(int_data);
   }
   if (real_data) {
     for (int i=0; i<nobb; i++) {
-      if (real_data[i]) free(real_data[i]);
+      if (real_data[i]) TIOGA_FREE(real_data[i]);
     }
-    free(real_data);
+    TIOGA_FREE(real_data);
   }
 }

--- a/src/getCartReceptors.C
+++ b/src/getCartReceptors.C
@@ -156,8 +156,8 @@ void MeshBlock::getCartReceptors(CartGrid *cg,parallelComm *pc)
 		      dataPtr->next=NULL;
 		    }
 		}
-	  free(xtm);
-	  free(itm);
+	  TIOGA_FREE(xtm);
+	  TIOGA_FREE(itm);
 	}
     }
   //
@@ -182,10 +182,10 @@ void MeshBlock::getCartReceptors(CartGrid *cg,parallelComm *pc)
   // if these were already allocated
   // get rid of them
   //
-  if (xsearch) free(xsearch);
-  if (isearch) free(isearch);
-  if (donorId) free(donorId);
-  if (rst) free(rst);
+  if (xsearch) TIOGA_FREE(xsearch);
+  if (isearch) TIOGA_FREE(isearch);
+  if (donorId) TIOGA_FREE(donorId);
+  if (rst) TIOGA_FREE(rst);
   //
   xsearch=(double *)malloc(sizeof(double)*3*nsearch);
   isearch=(int *)malloc(3*sizeof(int)*nsearch);
@@ -208,10 +208,10 @@ void MeshBlock::getCartReceptors(CartGrid *cg,parallelComm *pc)
     }
   deallocateLinkList3(head);
   //fclose(fp);
-  free(obcart);
-  free(pmap);
-  free(sndMap);
-  free(rcvMap);
+  TIOGA_FREE(obcart);
+  TIOGA_FREE(pmap);
+  TIOGA_FREE(sndMap);
+  TIOGA_FREE(rcvMap);
 }
 
   

--- a/src/highOrder.C
+++ b/src/highOrder.C
@@ -211,7 +211,7 @@ void MeshBlock::getInternalNodes(void)
   //
   nreceptorCells=0;
   //
-  if (ctag!=NULL) free(ctag);
+  if (ctag!=NULL) TIOGA_FREE(ctag);
   ctag=(int *)malloc(sizeof(int)*ncells);
   //
   for(i=0;i<ncells;i++)
@@ -219,7 +219,7 @@ void MeshBlock::getInternalNodes(void)
   //
   if (ihigh) 
     {
-      if (pointsPerCell!=NULL) free(pointsPerCell);
+      if (pointsPerCell!=NULL) TIOGA_FREE(pointsPerCell);
       pointsPerCell=(int *)malloc(sizeof(int)*nreceptorCells);
       //
       maxPointsPerCell=0;
@@ -229,10 +229,10 @@ void MeshBlock::getInternalNodes(void)
 	{
 	  get_nodes_per_cell(&(ctag[i]),&(pointsPerCell[i]));
 	  ntotalPoints+=pointsPerCell[i];
-	  maxPointsPerCell=MAX(maxPointsPerCell,pointsPerCell[i]);
+	  maxPointsPerCell=TIOGA_MAX(maxPointsPerCell,pointsPerCell[i]);
       }
       //
-      if (rxyz !=NULL) free(rxyz);
+      if (rxyz !=NULL) TIOGA_FREE(rxyz);
       //printf("getInternalNodes : %d %d\n",myid,ntotalPoints);
       rxyz=(double *)malloc(sizeof(double)*ntotalPoints*3);
       //
@@ -246,7 +246,7 @@ void MeshBlock::getInternalNodes(void)
   else
     {
       ntotalPoints=0;      
-      if (picked !=NULL) free(picked);
+      if (picked !=NULL) TIOGA_FREE(picked);
       picked=(int *) malloc(sizeof(int)*nnodes);
       for(i=0;i<nnodes;i++) {
         picked[i]=0;
@@ -256,7 +256,7 @@ void MeshBlock::getInternalNodes(void)
          }
       }
   
-      if (rxyz !=NULL) free(rxyz);
+      if (rxyz !=NULL) TIOGA_FREE(rxyz);
       rxyz=(double *)malloc(sizeof(double)*ntotalPoints*3);
       m=0;
       for(i=0;i<nnodes;i++)
@@ -315,7 +315,7 @@ void MeshBlock::getExtraQueryPoints(OBB *obc,
       (*realData)[m++]=BIGVALUE;
     }
   //
-  free(inode);
+  TIOGA_FREE(inode);
 }  
 
 void MeshBlock::processPointDonors(void)
@@ -341,10 +341,10 @@ void MeshBlock::processPointDonors(void)
   if (interpList2) {
     for(i=0;i<interp2ListSize;i++)
       {
-	if (interpList2[i].inode) free(interpList2[i].inode);
-	if (interpList2[i].weights) free(interpList2[i].weights);
+	if (interpList2[i].inode) TIOGA_FREE(interpList2[i].inode);
+	if (interpList2[i].weights) TIOGA_FREE(interpList2[i].weights);
       }
-    free(interpList2);
+    TIOGA_FREE(interpList2);
   } 
   interp2ListSize = ninterp2;
   interpList2=(INTERPLIST *)malloc(sizeof(INTERPLIST)*interp2ListSize);
@@ -415,7 +415,7 @@ void MeshBlock::processPointDonors(void)
 	    }
 	}
     }
-  free(frac);
+  TIOGA_FREE(frac);
 }
 
 void MeshBlock::getInterpolatedSolutionAtPoints(int *nints,int *nreals,int **intData,
@@ -434,7 +434,7 @@ void MeshBlock::getInterpolatedSolutionAtPoints(int *nints,int *nreals,int **int
   (*nints)=ninterp2;
   (*nreals)=ninterp2*nvar;
   if ((*nints)==0) {
-	free(qq);
+	TIOGA_FREE(qq);
 	return;
   }
   //
@@ -516,7 +516,7 @@ void MeshBlock::getInterpolatedSolutionAtPoints(int *nints,int *nreals,int **int
   //
   // no column-wise storage for high-order data
   //
-  free(qq);
+  TIOGA_FREE(qq);
 }
 	
 void MeshBlock::updatePointData(double *q,double *qtmp,int nvar,int interptype)  
@@ -549,7 +549,7 @@ void MeshBlock::updatePointData(double *q,double *qtmp,int nvar,int interptype)
 	    }
 	  m+=(pointsPerCell[i]*nvar);
 	}
-      free(qout);
+      TIOGA_FREE(qout);
     }
   else
     {

--- a/src/holeMap.C
+++ b/src/holeMap.C
@@ -69,7 +69,7 @@ void tioga::getHoleMap(void)
  if (holeMap) 
    {
      for(i=0;i<nmesh;i++)
-       if (holeMap[i].existWall) free(holeMap[i].sam);
+       if (holeMap[i].existWall) TIOGA_FREE(holeMap[i].sam);
      delete [] holeMap;
    }
  holeMap=new HOLEMAP[maxtag];
@@ -122,15 +122,15 @@ void tioga::getHoleMap(void)
        holeMap[i].extents[j + 3] = bboxGlobal[3 * i + j + 3 * maxtag];
        ds[j] = holeMap[i].extents[j + 3] - holeMap[i].extents[j];
      }
-     dsmax = MAX(ds[0], ds[1]);
-     dsmax = MAX(dsmax, ds[2]);
+     dsmax = TIOGA_MAX(ds[0], ds[1]);
+     dsmax = TIOGA_MAX(dsmax, ds[2]);
      dsbox = dsmax / 192;
 
      for (j = 0; j < 3; j++) {
        holeMap[i].extents[j] -= (2 * dsbox);
        holeMap[i].extents[j + 3] += (2 * dsbox);
        holeMap[i].nx[j] = floor(
-         MAX((holeMap[i].extents[j + 3] - holeMap[i].extents[j]) / dsbox, 1));
+         TIOGA_MAX((holeMap[i].extents[j + 3] - holeMap[i].extents[j]) / dsbox, 1));
      }
      bufferSize = holeMap[i].nx[0] * holeMap[i].nx[1] * holeMap[i].nx[2];
      holeMap[i].sam = (int*)malloc(sizeof(int) * bufferSize);
@@ -164,7 +164,7 @@ void tioga::getHoleMap(void)
    }
  //
  for(i=0;i<maxtag;i++)
-   if (holeMap[i].existWall) free(holeMap[i].samLocal);
+   if (holeMap[i].existWall) TIOGA_FREE(holeMap[i].samLocal);
  //
  // set the global number of meshes to maxtag
  //
@@ -181,10 +181,10 @@ void tioga::getHoleMap(void)
  //
  // free local memory
  //
- free(existHoleLocal);
- free(existHole);
- free(bboxLocal);
- free(bboxGlobal);
+ TIOGA_FREE(existHoleLocal);
+ TIOGA_FREE(existHole);
+ TIOGA_FREE(bboxLocal);
+ TIOGA_FREE(bboxGlobal);
 }
 
 /**

--- a/src/linklist.c
+++ b/src/linklist.c
@@ -24,7 +24,7 @@ void deallocateLinkList(DONORLIST *temp)
   if (temp!=NULL) 
     {
       deallocateLinkList(temp->next);
-      free(temp);
+      TIOGA_FREE(temp);
     }
 }
 
@@ -33,7 +33,7 @@ void deallocateLinkList2(INTEGERLIST *temp)
   if (temp!=NULL) 
     {
       deallocateLinkList2(temp->next);
-      free(temp);
+      TIOGA_FREE(temp);
     }
 }
 
@@ -41,10 +41,10 @@ void deallocateLinkList3(INTEGERLIST2 *temp)
 {
   if (temp!=NULL)
     {
-      if (temp->intData) free(temp->intData);
-      if (temp->realData) free(temp->realData);
+      if (temp->intData) TIOGA_FREE(temp->intData);
+      if (temp->realData) TIOGA_FREE(temp->realData);
       deallocateLinkList3(temp->next);
-      free(temp);
+      TIOGA_FREE(temp);
     }
 }
 
@@ -52,10 +52,10 @@ void deallocateLinkList4(INTERPLIST2 *temp)
 {
   if (temp!=NULL)
     {
-      if (temp->inode) free(temp->inode);
-      if (temp->weights) free(temp->weights);
+      if (temp->inode) TIOGA_FREE(temp->inode);
+      if (temp->weights) TIOGA_FREE(temp->weights);
       deallocateLinkList4(temp->next);
-      free(temp);
+      TIOGA_FREE(temp);
     }
 }
 

--- a/src/math.c
+++ b/src/math.c
@@ -20,7 +20,7 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-
+#include "codetypes.h"
 
 void solvec(double **a,double *b,int *iflag,int n)
 {
@@ -139,9 +139,9 @@ void newtonSolve(double f[7][3],double *u1,double *v1,double *w1)
   *u1=u;
   *v1=v;
   *w1=w;
-  for(i=0;i<3;i++) free(lhs[i]);
-  free(lhs);
-  free(rhs);
+  for(i=0;i<3;i++) TIOGA_FREE(lhs[i]);
+  TIOGA_FREE(lhs);
+  TIOGA_FREE(rhs);
   return;
 }
 
@@ -188,9 +188,9 @@ void computeNodalWeights(double xv[8][3],double *xp,double frac[8],int nvert)
 	  frac[0]=1.0;
 	  frac[1]=frac[2]=frac[3]=0;
 	}
-      for(i=0;i<3;i++) free(lhs[i]);
-      free(lhs);
-      free(rhs);
+      for(i=0;i<3;i++) TIOGA_FREE(lhs[i]);
+      TIOGA_FREE(lhs);
+      TIOGA_FREE(rhs);
       break;
     case 5:
       //

--- a/src/parallelComm.C
+++ b/src/parallelComm.C
@@ -85,12 +85,12 @@ void parallelComm::sendRecvPacketsAll(PACKET *sndPack, PACKET *rcvPack)
     }
   MPI_Waitall(irnum,request,status);
   
-  free(sint);
-  free(sreal);
-  free(rint);
-  free(rreal);
-  free(request);
-  free(status);
+  TIOGA_FREE(sint);
+  TIOGA_FREE(sreal);
+  TIOGA_FREE(rint);
+  TIOGA_FREE(rreal);
+  TIOGA_FREE(request);
+  TIOGA_FREE(status);
 }
 
 void parallelComm::sendRecvPackets(PACKET *sndPack,PACKET *rcvPack)
@@ -163,10 +163,10 @@ void parallelComm::sendRecvPackets(PACKET *sndPack,PACKET *rcvPack)
     }
   MPI_Waitall(irnum,request,status);
   //
-  free(scount);
-  free(rcount);
-  free(request);
-  free(status);
+  TIOGA_FREE(scount);
+  TIOGA_FREE(rcount);
+  TIOGA_FREE(request);
+  TIOGA_FREE(status);
 }
 
 void parallelComm::sendRecvPacketsCheck(PACKET *sndPack,PACKET *rcvPack)
@@ -249,18 +249,18 @@ void parallelComm::sendRecvPacketsCheck(PACKET *sndPack,PACKET *rcvPack)
     }
   MPI_Waitall(irnum,request,status);
   //
-  free(scount);
-  free(rcount);
-  free(request);
-  free(status);
+  TIOGA_FREE(scount);
+  TIOGA_FREE(rcount);
+  TIOGA_FREE(request);
+  TIOGA_FREE(status);
 }
 
 void parallelComm::setMap(int ns,int nr, int *snd,int *rcv)
 {
   int i;
   //
-  if (sndMap) free(sndMap); sndMap=NULL;
-  if (rcvMap) free(rcvMap); rcvMap=NULL;
+  if (sndMap) TIOGA_FREE(sndMap); sndMap=NULL;
+  if (rcvMap) TIOGA_FREE(rcvMap); rcvMap=NULL;
   //
   nsend=ns;
   nrecv=nr;
@@ -289,16 +289,16 @@ void parallelComm::clearPackets2(PACKET *sndPack, PACKET *rcvPack)
   //
   for(i=0;i<nsend;i++)
     {
-      if (sndPack[i].nints > 0) free(sndPack[i].intData);
-      if (sndPack[i].nreals > 0) free(sndPack[i].realData);
+      if (sndPack[i].nints > 0) TIOGA_FREE(sndPack[i].intData);
+      if (sndPack[i].nreals > 0) TIOGA_FREE(sndPack[i].realData);
       sndPack[i].intData=NULL;
       sndPack[i].realData=NULL;
       sndPack[i].nints=sndPack[i].nreals=0;
     }
   for(i=0;i<nrecv;i++)
     {
-      if (rcvPack[i].nints > 0) free(rcvPack[i].intData);
-      if (rcvPack[i].nreals > 0) free(rcvPack[i].realData);
+      if (rcvPack[i].nints > 0) TIOGA_FREE(rcvPack[i].intData);
+      if (rcvPack[i].nreals > 0) TIOGA_FREE(rcvPack[i].realData);
       rcvPack[i].intData=NULL;
       rcvPack[i].realData=NULL;
       rcvPack[i].nints=rcvPack[i].nreals=0;
@@ -315,17 +315,17 @@ void parallelComm::clearPackets(PACKET *sndPack, PACKET *rcvPack)
   for(i=0;i<nsend;i++)
     {
       //if (sndPack[i].nints > 0) 
-      if (sndPack[i].intData) free(sndPack[i].intData);
+      if (sndPack[i].intData) TIOGA_FREE(sndPack[i].intData);
       //if (sndPack[i].nreals > 0)
-      if (sndPack[i].realData) free(sndPack[i].realData);
+      if (sndPack[i].realData) TIOGA_FREE(sndPack[i].realData);
       sndPack[i].intData=NULL;
       sndPack[i].realData=NULL;
       sndPack[i].nints=sndPack[i].nreals=0;
     }
   for(i=0;i<nrecv;i++)
     {
-      if (rcvPack[i].intData) free(rcvPack[i].intData);
-      if (rcvPack[i].realData) free(rcvPack[i].realData);
+      if (rcvPack[i].intData) TIOGA_FREE(rcvPack[i].intData);
+      if (rcvPack[i].realData) TIOGA_FREE(rcvPack[i].realData);
       rcvPack[i].intData=NULL;
       rcvPack[i].realData=NULL;
       rcvPack[i].nints=rcvPack[i].nreals=0;

--- a/src/search.C
+++ b/src/search.C
@@ -86,8 +86,8 @@ findOBB(xsearch,obq->xc,obq->dxc,obq->vec,nsearch);
 		  xd[j]=0;
 		  for(k=0;k<3;k++)
 		    xd[j]+=(x[i3+k]-obq->xc[k])*obq->vec[j][k];
-		  xmin[j]=MIN(xmin[j],xd[j]);
-		  xmax[j]=MAX(xmax[j],xd[j]);
+		  xmin[j]=TIOGA_MIN(xmin[j],xd[j]);
+		  xmax[j]=TIOGA_MAX(xmax[j],xd[j]);
 		}
 	      for(j=0;j<3;j++)
 		{
@@ -118,8 +118,8 @@ findOBB(xsearch,obq->xc,obq->dxc,obq->vec,nsearch);
   // ADT
   //
 
-  if (elementBbox) free(elementBbox);
-  if (elementList) free(elementList);
+  if (elementBbox) TIOGA_FREE(elementBbox);
+  if (elementList) TIOGA_FREE(elementList);
   elementBbox=(double *)malloc(sizeof(double)*cell_count*6);
   elementList=(int *)malloc(sizeof(int)*cell_count);
   //
@@ -148,8 +148,8 @@ findOBB(xsearch,obq->xc,obq->dxc,obq->vec,nsearch);
 	  i3=3*(vconn[n][nvert*i+m]-BASE);
 	  for(j=0;j<3;j++)
 	    {
-	      xmin[j]=MIN(xmin[j],x[i3+j]);
-	      xmax[j]=MAX(xmax[j],x[i3+j]);
+	      xmin[j]=TIOGA_MIN(xmin[j],x[i3+j]);
+	      xmax[j]=TIOGA_MAX(xmax[j],x[i3+j]);
 	    }
 	}
       //
@@ -179,9 +179,9 @@ findOBB(xsearch,obq->xc,obq->dxc,obq->vec,nsearch);
   //
   adt->buildADT(ndim,cell_count,elementBbox);
   //
-  if (donorId) free(donorId);
+  if (donorId) TIOGA_FREE(donorId);
   donorId=(int*)malloc(sizeof(int)*nsearch);
-  if (xtag) free(xtag);
+  if (xtag) TIOGA_FREE(xtag);
   xtag=(int *)malloc(sizeof(int)*nsearch);
   //
   // create a unique hash
@@ -206,8 +206,8 @@ findOBB(xsearch,obq->xc,obq->dxc,obq->vec,nsearch);
 	}
        ipoint+=3;
     }
-  free(dId);
+  TIOGA_FREE(dId);
   //
-  free(icell);
-  free(obq);
+  TIOGA_FREE(icell);
+  TIOGA_FREE(obq);
 }

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -136,7 +136,7 @@ void tioga::performConnectivity(void)
     }
     mb->writeGridFile(100*myid+mtags[ib]);
   }
-  if (qblock) free(qblock);
+  if (qblock) TIOGA_FREE(qblock);
   qblock=(double **)malloc(sizeof(double *)*nblocks);
   for(int ib=0;ib<nblocks;ib++)
     qblock[ib]=NULL;
@@ -310,12 +310,12 @@ void tioga::dataUpdate_AMR(int nvar,int interptype)
   // release all memory
   //
   pc_cart->clearPackets2(sndPack,rcvPack);
-  free(sndPack);
-  free(rcvPack);
-  if (integerRecords) free(integerRecords);
-  if (realRecords) free(realRecords);
-  if (icount) free(icount);
-  if (dcount) free(dcount);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
+  if (integerRecords) TIOGA_FREE(integerRecords);
+  if (realRecords) TIOGA_FREE(realRecords);
+  if (icount) TIOGA_FREE(icount);
+  if (dcount) TIOGA_FREE(dcount);
 }
 
 void tioga::dataUpdate(int nvar,int interptype, int at_points)
@@ -485,26 +485,26 @@ void tioga::dataUpdate(int nvar,int interptype, int at_points)
   // release all memory
   //
   pc->clearPackets2(sndPack,rcvPack);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
   if (integerRecords) {
-    for(int ib=0;ib<nblocks;ib++) if (integerRecords[ib]) free(integerRecords[ib]);
-    free(integerRecords);
+    for(int ib=0;ib<nblocks;ib++) if (integerRecords[ib]) TIOGA_FREE(integerRecords[ib]);
+    TIOGA_FREE(integerRecords);
   }
   if (realRecords) {
     for(int ib=0;ib<nblocks;ib++)
-      if (realRecords[ib]) free(realRecords[ib]);
-    free(realRecords);
+      if (realRecords[ib]) TIOGA_FREE(realRecords[ib]);
+    TIOGA_FREE(realRecords);
   }
   if (qtmp) {
     for (int ib =0;ib<nblocks;ib++)
-      if (qtmp[ib]) free(qtmp[ib]);
-      free(qtmp);
+      if (qtmp[ib]) TIOGA_FREE(qtmp[ib]);
+      TIOGA_FREE(qtmp);
   }
   if (itmp) {
     for(int ib=0;ib<nblocks;ib++)
-     if (itmp[ib]) free(itmp[ib]);
-    free(itmp);
+     if (itmp[ib]) TIOGA_FREE(itmp[ib]);
+    TIOGA_FREE(itmp);
   }
 }
 
@@ -635,8 +635,8 @@ void tioga::getReceptorInfo(std::vector<int>& receptors)
   }
 
   pc->clearPackets(sndPack, rcvPack);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
 }
 
 tioga::~tioga()
@@ -645,15 +645,15 @@ tioga::~tioga()
   if (holeMap)
     {
       for(i=0;i<nmesh;i++)
-	if (holeMap[i].existWall) free(holeMap[i].sam);
+	if (holeMap[i].existWall) TIOGA_FREE(holeMap[i].sam);
       delete [] holeMap;
     }
   if (pc) delete[] pc;
   if (pc_cart) delete[] pc_cart;
-  if (sendCount) free(sendCount);
-  if (recvCount) free(recvCount);
+  if (sendCount) TIOGA_FREE(sendCount);
+  if (recvCount) TIOGA_FREE(recvCount);
 
-  if (qblock) free(qblock);
+  if (qblock) TIOGA_FREE(qblock);
   if (myid==0) printf("#tioga :successfully cleared all the memory accessed\n");
 };
 
@@ -788,7 +788,7 @@ void tioga::reduce_fringes(void)
   //
   for (int i=0; i<nblocks; i++) {
     if (donorRecords[i]) {
-      free(donorRecords[i]);
+      TIOGA_FREE(donorRecords[i]);
       donorRecords[i] = NULL;
     }
     nrecords[i] = 0;    
@@ -831,14 +831,14 @@ void tioga::reduce_fringes(void)
       }
   }
   pc->clearPackets(sndPack,rcvPack);
-  free(sndPack);
-  free(rcvPack);
+  TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
   
   if (donorRecords) {
     for (int i=0; i<nblocks; i++) {
-      if (donorRecords[i]) free(donorRecords[i]);
+      if (donorRecords[i]) TIOGA_FREE(donorRecords[i]);
     }
-    free(donorRecords);
+    TIOGA_FREE(donorRecords);
   }
   outputStatistics();
   //mb->writeOBB(myid);

--- a/src/tiogaInterface.C
+++ b/src/tiogaInterface.C
@@ -89,9 +89,9 @@ extern "C" {
     int iblk=0;
     va_start(arguments, ntypes);
 
-    if(idata[iblk].nv) free(idata[iblk].nv);
-    if(idata[iblk].nc) free(idata[iblk].nc);
-    if(idata[iblk].vconn) free(idata[iblk].vconn);
+    if(idata[iblk].nv) TIOGA_FREE(idata[iblk].nv);
+    if(idata[iblk].nc) TIOGA_FREE(idata[iblk].nc);
+    if(idata[iblk].vconn) TIOGA_FREE(idata[iblk].vconn);
     idata[iblk].nv=(int *) malloc(sizeof(int)*(*ntypes));    
     idata[iblk].nc=(int *) malloc(sizeof(int)*(*ntypes));
     idata[iblk].vconn=(int **)malloc(sizeof(int *)*(*ntypes));
@@ -114,9 +114,9 @@ extern "C" {
 
     va_start(arguments, ntypes);
 
-    if(idata[iblk].nv) free(idata[iblk].nv);
-    if(idata[iblk].nc) free(idata[iblk].nc);
-    if(idata[iblk].vconn) free(idata[iblk].vconn);
+    if(idata[iblk].nv) TIOGA_FREE(idata[iblk].nv);
+    if(idata[iblk].nc) TIOGA_FREE(idata[iblk].nc);
+    if(idata[iblk].vconn) TIOGA_FREE(idata[iblk].vconn);
     idata[iblk].nv=(int *) malloc(sizeof(int)*(*ntypes));    
     idata[iblk].nc=(int *) malloc(sizeof(int)*(*ntypes));
     idata[iblk].vconn=(int **)malloc(sizeof(int *)*(*ntypes));
@@ -319,9 +319,9 @@ extern "C" {
     delete [] tg;
     for(int i=0;i<MAXBLOCKS;i++)
      {
-       if (idata[i].nc) free(idata[i].nc);
-       if (idata[i].nv) free(idata[i].nv);
-       if (idata[i].vconn) free(idata[i].vconn);
+       if (idata[i].nc) TIOGA_FREE(idata[i].nc);
+       if (idata[i].nv) TIOGA_FREE(idata[i].nv);
+       if (idata[i].vconn) TIOGA_FREE(idata[i].vconn);
      }
    }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -63,9 +63,9 @@ void findOBB(double *x,double xc[3],double dxc[3],double vec[3][3],int nnodes)
 	}
       else if (nnodes==2)
 	{
-	  dxc[0]=MAX(1e-3,fabs(x[3]-x[0]))*0.5;
-	  dxc[1]=MAX(1e-3,fabs(x[4]-x[1]))*0.5;
-	  dxc[2]=MAX(1e-3,fabs(x[5]-x[2]))*0.5;
+	  dxc[0]=TIOGA_MAX(1e-3,fabs(x[3]-x[0]))*0.5;
+	  dxc[1]=TIOGA_MAX(1e-3,fabs(x[4]-x[1]))*0.5;
+	  dxc[2]=TIOGA_MAX(1e-3,fabs(x[5]-x[2]))*0.5;
           return;
 	}
       else
@@ -74,7 +74,7 @@ void findOBB(double *x,double xc[3],double dxc[3],double vec[3][3],int nnodes)
           {
            i3=3*i;
            for(j=0;j<3;j++)
-            dxc[j]=MAX(1e-3,fabs(x[i3+j]-x[0]));
+            dxc[j]=TIOGA_MAX(1e-3,fabs(x[i3+j]-x[0]));
           }
 	 return;
         }
@@ -137,8 +137,8 @@ void findOBB(double *x,double xc[3],double dxc[3],double vec[3][3],int nnodes)
       //
       for(j=0;j<3;j++)
 	{
-	  xmax[j]=MAX(xmax[j],xd[j]);
-	  xmin[j]=MIN(xmin[j],xd[j]);
+	  xmax[j]=TIOGA_MAX(xmax[j],xd[j]);
+	  xmin[j]=TIOGA_MIN(xmin[j],xd[j]);
 	}
     }
   //
@@ -161,8 +161,8 @@ void findOBB(double *x,double xc[3],double dxc[3],double vec[3][3],int nnodes)
       xc[j]+=(xd[k]*vec[k][j]);
     }
   //
-  free(aa);
-  free(eigenv);
+  TIOGA_FREE(aa);
+  TIOGA_FREE(eigenv);
 }
 /**
  check if a point is inside the
@@ -460,8 +460,8 @@ void uniquenodes(double *x,int *meshtag,double *rtag,int *itag,int *nn)
   
   for(i=0;i<nnodes;i++)
     for(j=0;j<3;j++) {
-      xmax[j]=MAX(xmax[j],x[3*i+j]);
-      xmin[j]=MIN(xmin[j],x[3*i+j]);
+      xmax[j]=TIOGA_MAX(xmax[j],x[3*i+j]);
+      xmin[j]=TIOGA_MIN(xmin[j],x[3*i+j]);
     }
 
   ds=(xmax[0]-xmin[0]+xmax[1]-xmin[1]+xmax[2]-xmin[2])/3.0/NSUB;
@@ -469,16 +469,16 @@ void uniquenodes(double *x,int *meshtag,double *rtag,int *itag,int *nn)
   for(j=0;j<3;j++) xmax[j]+=ds;
   for(j=0;j<3;j++) xmin[j]-=ds;
   
-  jmax=MIN(round((xmax[0]-xmin[0])*dsi),NSUB);
-  jmax=MAX(jmax,1);
+  jmax=TIOGA_MIN(round((xmax[0]-xmin[0])*dsi),NSUB);
+  jmax=TIOGA_MAX(jmax,1);
   dsx=(xmax[0]-xmin[0]+TOL)/jmax;
   dsxi=1./dsx;    
-  kmax=MIN(round((xmax[1]-xmin[1])*dsi),NSUB);
-  kmax=MAX(kmax,1);
+  kmax=TIOGA_MIN(round((xmax[1]-xmin[1])*dsi),NSUB);
+  kmax=TIOGA_MAX(kmax,1);
   dsy=(xmax[1]-xmin[1]+TOL)/kmax;
   dsyi=1./dsy;
-  lmax=MIN(round((xmax[2]-xmin[2])*dsi),NSUB);
-  lmax=MAX(lmax,1);
+  lmax=TIOGA_MIN(round((xmax[2]-xmin[2])*dsi),NSUB);
+  lmax=TIOGA_MAX(lmax,1);
   dsz=(xmax[2]-xmin[2]+TOL)/lmax;
   dszi=1./dsz;
   nsblks=jmax*kmax*lmax;
@@ -526,11 +526,11 @@ void uniquenodes(double *x,int *meshtag,double *rtag,int *itag,int *nn)
                  meshtag[p1]==meshtag[p2])
 	      {
 		if (p1 > p2) {
-		  rtag[p2]=MAX(rtag[p1],rtag[p2]);
+		  rtag[p2]=TIOGA_MAX(rtag[p1],rtag[p2]);
 		  itag[p1]=p2;
 		}
 		else {
-		  rtag[p1]=MAX(rtag[p1],rtag[p2]);
+		  rtag[p1]=TIOGA_MAX(rtag[p1],rtag[p2]);
 		  itag[p2]=p1;
 		}
 	      }
@@ -543,9 +543,9 @@ void uniquenodes(double *x,int *meshtag,double *rtag,int *itag,int *nn)
      m++;
    }
   */
-  free(ilist);
-  free(cft);
-  free(numpts);
+  TIOGA_FREE(ilist);
+  TIOGA_FREE(cft);
+  TIOGA_FREE(numpts);
 }
   
 		 

--- a/src/writeOutput.C
+++ b/src/writeOutput.C
@@ -21,10 +21,6 @@
 #include<stdlib.h>
 #define REAL double
 #include "inputBlk.h"
-#define BIGVAL 1E16
-#define MIN(A,B) (A)<(B)?(A):(B)
-#define MAX(A,B) (A)>(B)?(A):(B)
-
 
 void MeshBlock::writeOutput(int bid)
 {


### PR DESCRIPTION
Replace all macros (Min/Max, MIN/MAX, and free) with TIOGA_ prefixed
versions to avoid conflicts with builtins as well as other codes.