### PR TITLE
Change free to TIOGA_FREE in resetInterpData().

### DIFF
--- a/src/MeshBlock.h
+++ b/src/MeshBlock.h
@@ -314,11 +314,11 @@ class MeshBlock
     if (interpList) {
       for (int i = 0; i < interpListSize; i++) {
         if (interpList[i].inode)
-          free(interpList[i].inode);
+          TIOGA_FREE(interpList[i].inode);
         if (interpList[i].weights)
-          free(interpList[i].weights);
+          TIOGA_FREE(interpList[i].weights);
       }
-      free(interpList);
+      TIOGA_FREE(interpList);
     }
     ninterp = 0;
     interpListSize = 0;


### PR DESCRIPTION
Following the resent addition of MACROS, this ensures that `interpList` is actually set to `NULL`.