### PR TITLE
Fix handling of cellGID field in MeshBlock for large meshes

### DIFF
--- a/src/dataUpdate.C
+++ b/src/dataUpdate.C
@@ -167,6 +167,10 @@ void MeshBlock::getReceptorInfo(int *receptors)
     receptors[k++] = interpList[i].receptorInfo[2];
 
     int donID = interpList[i].inode[interpList[i].nweights];
-    receptors[k++] = cellGID[donID];
+
+    // Copy the contents of uint64_t (8 bytes) into 2 4-byte locations in the
+    // array
+    memcpy(&receptors[k], &cellGID[donID], sizeof(uint64_t));
+    k += 2;
   }
 }

--- a/src/tioga.h
+++ b/src/tioga.h
@@ -30,6 +30,12 @@
 #include "CartBlock.h"
 #include "parallelComm.h"
 
+/** Define a macro entry flagging the versions that are safe to use with large
+ *  meshes containing element and node IDs greater than what a 4-byte signed int
+ *  can support
+ */
+#define TIOGA_HAS_UINT64T 1
+
 /**
  * Topology Indpendent Overset Grid Assembler (TIOGA)
  * Base class and dependencies


### PR DESCRIPTION
`cellGID` is a `uint64_t` datatype that was being truncated to a 4-byte in
in the `MeshBlock::getReceptorInfo` method, this was fine for small meshes
but does not work for meshes greater than 2.4B elements. This commit
fixes this by handling the 64-bit data across 2 4-byte integer entries
within the int data structures.