### PR TITLE
Fixes to scaling issues with Nalu-Wind

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(TIOGA CXX C Fortran)
 option(BUILD_SHARED_LIBS "Build shared libraries (default: off)" on)
 option(BUILD_TIOGA_EXE "Build tioga driver code (default: off)" on)
 option(BUILD_GRIDGEN_EXE "Build grid generator code (default: off)" on)
+option(TIOGA_HAS_NODEGID "Support node global IDs (default: on)" on)
 
 find_package(MPI REQUIRED)
 include_directories(${MPI_INCLUDE_PATH})
@@ -32,6 +33,10 @@ endif()
 if (BUILD_SHARED_LIBS)
   set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ON)
+endif()
+
+if (TIOGA_HAS_NODEGID)
+  add_definitions(-DTIOGA_HAS_NODEGID)
 endif()
 
 # Always build libtioga

--- a/cmake/TIOGAConfig.cmake.in
+++ b/cmake/TIOGAConfig.cmake.in
@@ -34,6 +34,9 @@ set(TIOGA_Fortran_COMPILER_FLAGS "@CMAKE_Fortran_FLAGS@")
 set_and_check(TIOGA_INCLUDE_DIRS "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set_and_check(TIOGA_LIBRARY_DIRS "@PACKAGE_LIB_INSTALL_DIR@")
 
+# Flag indicating whether TIOGA uses NODE GID
+set(TIOGA_HAS_NODEGID @TIOGA_HAS_NODEGID@)
+
 set(TIOGA_LIBRARIES "tioga")
 
 include("${CMAKE_CURRENT_LIST_DIR}/TIOGALibraries.cmake")

--- a/src/MeshBlock.C
+++ b/src/MeshBlock.C
@@ -19,6 +19,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "codetypes.h"
 #include "MeshBlock.h"
+#include <cstring>
+
 extern "C" {
   void findOBB(double *x,double xc[3],double dxc[3],double vec[3][3],int nnodes);
   double computeCellVolume(double xv[8][3],int nvert);

--- a/src/MeshBlock.h
+++ b/src/MeshBlock.h
@@ -54,6 +54,7 @@ class MeshBlock
   int *wbcnode;     /** < wall boundary node indices */
   int *obcnode;     /** < overset boundary node indices */
   uint64_t *cellGID;     /**< Global ID of the cell */
+  uint64_t *nodeGID;     /**< Global ID for the nodes */
   //
   double *nodeRes;  /** < node resolution  */
   double *userSpecifiedNodeRes;
@@ -128,6 +129,7 @@ class MeshBlock
   double *xsearch;    /** < coordinates of the query points */
   double *rst;            /**  natrural coordinates */
   int *donorId;       /** < donor indices for those found */
+  std::vector<uint64_t> gid_search; /**< Global node ID for the query points */
   int donorCount;
   int myid;
   double *cellRes;  /** < resolution for each cell */
@@ -188,7 +190,7 @@ class MeshBlock
   void setData(int btag,int nnodesi,double *xyzi, int *ibli,int nwbci, int nobci, 
 	       int *wbcnodei,int *obcnodei,
                int ntypesi, int *nvi, int *nci, int **vconni,
-               uint64_t* cell_gid=NULL);
+               uint64_t* cell_gid=NULL, uint64_t* node_gid=NULL);
 
 
   void setResolutions(double *nres,double *cres);    

--- a/src/exchangeBoxes.C
+++ b/src/exchangeBoxes.C
@@ -40,6 +40,8 @@ void tioga::exchangeBoxes(void)
   PACKET *sndPack,*rcvPack;
 
   std::vector<int> nbPerProc(numprocs); // Number of chunks per processor
+  std::vector<int> obSizePerProc(numprocs); // Number of real data (OBBs) per processor
+
   MPI_Allgather(&nblocks, 1, MPI_INT, nbPerProc.data(), 1, MPI_INT, scomm);
 
   // Total number mesh chunks across all procs
@@ -50,8 +52,10 @@ void tioga::exchangeBoxes(void)
   std::vector<bool> sendFlag(numprocs,false); // Flag indicating send/recv from this proc
 
   displs[0] = 0;
+  obSizePerProc[0]=nbPerProc[0]*16;
   for (int i=1; i <= numprocs; i++) {
     displs[i] = displs[i-1] + nbPerProc[i-1];
+    if (i < numprocs) obSizePerProc[i]=nbPerProc[i]*16;
   }
 
   MPI_Allgatherv(mytag.data(), nblocks, MPI_INT, alltags.data(),
@@ -65,114 +69,51 @@ void tioga::exchangeBoxes(void)
   }
   int mxtgsqr = maxtag * maxtag;
 
-  //
-  // count number of other processors to communicate to
-  // in overset grid scenario, usually you do not communicate
-  // to mesh blocks that carry the same mesh tag (i.e. you don't
-  // talk to your sister partitions)
-  //
-  nsend = 0;
-  for (int p=0; p < numprocs; p++) {
+  displs[0] = 0;
+  for (int i=1; i <= numprocs; i++) {
+    displs[i] = displs[i-1] + nbPerProc[i-1]*16;
+  }
+  
+  std::vector<double> myOBBdata(nblocks*16);
+  std::vector<double> allOBBdata(ntotalblks*16);
 
-    for(int d=displs[p]; d < displs[p+1]; d++) {
-      for (int ib=0; ib < nblocks; ib++) {
-        if (abs(alltags[d]) != mtags[ib]) {
-          nsend++;
-          sendFlag[p] = true;
-          break;
-        }
-      }
-      if (sendFlag[p]) break;
-    }
+  int m=0;
+  for (int ib=0; ib < nblocks; ib++) {
+    myOBBdata[m++] = (double)mytag[ib];
+    for (int i=0; i < 3; i++)
+      for (int j=0; j< 3; j++)
+	myOBBdata[m++] = mblocks[ib]->obb->vec[i][j];
+    for (int i=0; i< 3; i++)
+      myOBBdata[m++] = mblocks[ib]->obb->xc[i];
+    for (int i=0; i< 3; i++)
+      myOBBdata[m++] = mblocks[ib]->obb->dxc[i];
   }
 
-  // In general we communicate forward
-  // and backward, separate lists are maintained for
-  // flexibility
-  //
-  nrecv = nsend;
-
-  sndMap = (int*)malloc(sizeof(int) * nsend);
-  rcvMap = (int*)malloc(sizeof(int) * nrecv);
-
-  for (int i=0, ig=0; i < numprocs; i++) {
-    if (sendFlag[i] == true) {
-      sndMap[ig] = i;
-      rcvMap[ig] = i;
-      ig++;
-    }
-  }
-  pc->setMap(nsend,nrecv,sndMap,rcvMap);
-
-  sndPack=(PACKET *)malloc(sizeof(PACKET)*nsend);
-  rcvPack=(PACKET *)malloc(sizeof(PACKET)*nrecv);
-
-  // Populate sndPack data
-  for (int k=0; k < nsend; k++) {
-    std::vector<bool> bFlag(nblocks, false);
-    int ip = sndMap[k];
-    sndPack[k].nints = 0;
-
-    // Determine buffer sizes
-    for (int ib=0; ib < nblocks; ib++) {
-      for (int d=displs[ip]; d < displs[ip+1]; d++) {
-        if (( abs(alltags[d]) != mtags[ib] ) &&
-            ( bFlag[ib] == false)) {
-          sndPack[k].nints++;
-          bFlag[ib] = true;
-        }
-      }
-    }
-    sndPack[k].nreals = 15 * sndPack[k].nints;
-    sndPack[k].intData = (int*) malloc(sizeof(int)*sndPack[k].nints);
-    sndPack[k].realData = (double*) malloc(sizeof(double)*sndPack[k].nreals);
-
-    // Populate int and real data arrays
-    int im = 0;
-    int m = 0;
-    for (int ib=0; ib < nblocks; ib++) {
-      if (bFlag[ib] == false) continue;
-
-      sndPack[k].intData[im++] = mytag[ib];
-
-      for (int i=0; i < 3; i++)
-        for (int j=0; j< 3; j++)
-          sndPack[k].realData[m++] = mblocks[ib]->obb->vec[i][j];
-
-      for (int i=0; i< 3; i++)
-        sndPack[k].realData[m++] = mblocks[ib]->obb->xc[i];
-
-      for (int i=0; i< 3; i++)
-        sndPack[k].realData[m++] = mblocks[ib]->obb->dxc[i];
-    }
-  }
-  pc->sendRecvPackets(sndPack, rcvPack);
+  MPI_Allgatherv(myOBBdata.data(), nblocks*16, MPI_DOUBLE, allOBBdata.data(),
+                 obSizePerProc.data(), displs.data(), MPI_DOUBLE, scomm);
 
   // Determine total number of OBBs received 
-  int nobb = 0;
-  for (int k=0; k < nrecv; k++)
-    nobb += rcvPack[k].nints;
+  int nobb = ntotalblks;
 
   // Store all received OBBs in a temporary list
   std::vector<OBB> obbRecv(nobb);
   std::vector<int> obbID(nobb); // Mesh tag corresponding to the OBB
   std::vector<int> obbProc(nobb); // Proc ID corresponding to OBB
-
-  for(int k=0, ix=0; k < nrecv; k++) {
-    int m = 0;
-    int im = 0;
-    for (int n=0; n < rcvPack[k].nints; n++) {
-      obbProc[ix] = rcvMap[k];
-      obbID[ix] = rcvPack[k].intData[im++];
-      for (int i=0; i<3; i++)
-        for (int j=0; j<3; j++)
-          obbRecv[ix].vec[i][j] = rcvPack[k].realData[m++];
-
-      for (int i=0; i<3; i++)
-        obbRecv[ix].xc[i] = rcvPack[k].realData[m++];
+  m=0;
+  for(int k=0,ix=0;k < numprocs;k++) {
+    for (int n=0;n < nbPerProc[k];n++)
+      {
+	obbProc[ix]=k;
+	obbID[ix]=(int)(allOBBdata[m++]+0.5);
+	for (int i=0; i<3; i++)
+	  for (int j=0; j<3; j++)
+	    obbRecv[ix].vec[i][j] = allOBBdata[m++];
 
       for (int i=0; i<3; i++)
-        obbRecv[ix].dxc[i] = rcvPack[k].realData[m++];
+        obbRecv[ix].xc[i] = allOBBdata[m++];
+
+      for (int i=0; i<3; i++)
+        obbRecv[ix].dxc[i] = allOBBdata[m++];
 
       ix++;
     }
@@ -188,11 +129,11 @@ void tioga::exchangeBoxes(void)
   //
   // Check for intersection of OBBs
   //
+  nsend=nrecv=numprocs;
   for (int ob=0; ob < nobb; ob++) {
     for (int ib=0; ib < nblocks; ib++) {
       auto& mb = mblocks[ib];
       int meshtag = mb->getMeshTag();
-
         if (abs(obbID[ob]) == meshtag) continue;
 
         if ( obbIntersectCheck(
@@ -217,10 +158,16 @@ void tioga::exchangeBoxes(void)
   }
   int new_send = std::count(sendFlag.begin(), sendFlag.end(), true);
   assert(new_send <= nsend);
-
   // Populate send and recv maps
   std::map<int,int> invMap;
   nsend = nrecv = new_send;
+
+  // allocate sndMap and rcvMap
+  sndMap = (int*)malloc(sizeof(int) * nsend);
+  rcvMap = (int*)malloc(sizeof(int) * nrecv);
+  sndPack=(PACKET *)malloc(sizeof(PACKET)*nsend);
+  rcvPack=(PACKET *)malloc(sizeof(PACKET)*nrecv);
+
   for (int p=0, ip=0; p < numprocs; p++)
     if (sendFlag[p]) {
       sndMap[ip] = p;
@@ -230,8 +177,8 @@ void tioga::exchangeBoxes(void)
     }
 
   // clear packets before nsend and nrecv are modified in pc->setMap
-  pc->clearPackets(sndPack,rcvPack);
   pc->setMap(nsend,nrecv,sndMap,rcvMap);
+  pc->initPackets(sndPack,rcvPack);
 
 
   // if (obblist) TIOGA_FREE(obblist);

--- a/src/exchangeSearchData.C
+++ b/src/exchangeSearchData.C
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <cstring>
 #include "codetypes.h"
 #include "tioga.h"
 using namespace TIOGA;

--- a/src/exchangeSearchData.C
+++ b/src/exchangeSearchData.C
@@ -143,7 +143,16 @@ void tioga::exchangeSearchData(int at_points)
        mb->rst=NULL;
      }
     }
+#ifdef TIOGA_HAS_NODEGID
+   mb->gid_search.clear();
+#endif
   }
+
+#ifdef TIOGA_HAS_NODEGID
+  int nintsPerNode = 3;
+#else
+  int nintsPerNode = 1;
+#endif
 
   // Loop through recv packets and estimate search array sizes in MeshBlock data
   // structures
@@ -161,9 +170,11 @@ void tioga::exchangeSearchData(int at_points)
       nintsRecv[ii] = rcvPack[k].intData[m++];
       nrealsRecv[ii] = rcvPack[k].intData[m++];
 
-      mb->nsearch += nintsRecv[ii];
-      // Skip the node indices
+      // Skip the nodal data (indices and global IDs)
       m += nintsRecv[ii];
+      // Adjust for node GIDs if available
+      nintsRecv[ii] /= nintsPerNode;
+      mb->nsearch += nintsRecv[ii];
     }
   }
 
@@ -176,14 +187,19 @@ void tioga::exchangeSearchData(int at_points)
     mb->isearch = (int*)malloc(3 * sizeof(int) * mb->nsearch);
     mb->tagsearch = (int*)malloc(sizeof(int) * mb->nsearch);
     mb->donorId = (int*)malloc(sizeof(int) * mb->nsearch);
+#ifdef TIOGA_HAS_NODEGID
+    mb->gid_search.resize(mb->nsearch);
+#endif
     if (at_points==1) mb->rst = (double*)malloc(sizeof(double) * 3 * mb->nsearch);
   }
+
   //
   // Update search arrays in mesh blocks from recv packets
   //
   std::vector<int> icOffset(nblocks,0); // Index of isearch arrays where next fill happens
   std::vector<int> dcOffset(nblocks, 0); // Index of xsearch arrays where next fill happens
   std::vector<int> rcOffset(nblocks, 0); // Index of res_search arrays where next fill happens
+  std::vector<int> igOffset(nblocks, 0); // Index of gid_search where next fill happens
   for (int k=0; k < nrecv; k++) {
     int l = 0;
     int m = 0;
@@ -197,24 +213,32 @@ void tioga::exchangeSearchData(int at_points)
       int ioff = icOffset[ib];
       int doff = dcOffset[ib];
       int roff = rcOffset[ib];
+      int goff = igOffset[ib];
 
       m += 2; // Skip nints and nreals information
       for (int j=0; j < nintsRecv[ii]; j++) {
         mb->isearch[ioff++] = k;
         mb->isearch[ioff++] = rcvPack[k].intData[m++];
-	mb->isearch[ioff++] = obblist[ii].iblk_remote;
+        mb->isearch[ioff++] = obblist[ii].iblk_remote;
         mb->tagsearch[ioff/3-1]=obblist[ii].tag_remote;
+
+#ifdef TIOGA_HAS_NODEGID
+        std::memcpy(&(mb->gid_search[goff]), &(rcvPack[k].intData[m]), sizeof(uint64_t));
+        m += 2;
+        goff++;
+#endif
       }
 
-      for (int j=0; j < nrealsRecv[ii]/4; j++) {
-        for(int mm=0;mm<3;mm++)
+      for (int j = 0; j < nrealsRecv[ii] / 4; j++) {
+        for (int mm = 0; mm < 3; mm++)
           mb->xsearch[doff++] = rcvPack[k].realData[l++];
-        mb->res_search[roff++]= rcvPack[k].realData[l++];
+        mb->res_search[roff++] = rcvPack[k].realData[l++];
       }
 
       icOffset[ib] = ioff;
       dcOffset[ib] = doff;
       rcOffset[ib] = roff;
+      igOffset[ib] = goff;
     }
   }
 

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -63,7 +63,7 @@ void tioga::setCommunicator(MPI_Comm communicator, int id_proc, int nprocs)
  */
 void tioga::registerGridData(int btag,int nnodes,double *xyz,int *ibl, int nwbc,int nobc,
                              int *wbcnode,int *obcnode,int ntypes, int *nv, int *nc, int **vconn,
-                             uint64_t* cell_gid)
+                             uint64_t* cell_gid, uint64_t* node_gid)
 {
   int iblk;
 
@@ -80,9 +80,9 @@ void tioga::registerGridData(int btag,int nnodes,double *xyz,int *ibl, int nwbc,
   }
 
   auto& mb = mblocks[iblk];
-  mb->setData(btag,nnodes,xyz,ibl,nwbc,nobc,wbcnode,obcnode,ntypes,nv,nc,vconn, cell_gid);
-  mb->myid=myid;
-
+  mb->setData(btag, nnodes, xyz, ibl, nwbc, nobc, wbcnode, obcnode, ntypes, nv,
+              nc, vconn, cell_gid, node_gid);
+  mb->myid = myid;
 }
 
 void tioga::registerSolution(int btag,double *q)

--- a/src/tioga.h
+++ b/src/tioga.h
@@ -120,7 +120,7 @@ class tioga
 
   void registerGridData(int btag,int nnodes,double *xyz,int *ibl, int nwbc,int nobc,
                         int *wbcnode,int *obcnode,int ntypes, int *nv, int *nc, int **vconn,
-                        uint64_t* cell_gid=NULL);
+                        uint64_t* cell_gid=NULL, uint64_t* node_gid=NULL);
 
   void registerSolution(int btag,double *q);
 


### PR DESCRIPTION
This pull request adds a few modifications to fix scaling issues observed on 16k/32k MPI ranks on NERSC Cori system

- Use `MPI_AllReduce` to exchange boxes instead of send/recv of a large number of boxes
- Add option to determine _unique nodes_ using global node ID instead of coincident coordinate search. Can be disabled using the CMake option `-DTIOGA_HAS_NODEGID=OFF`