### PR TITLE
Revert to old behavior for iblank_cell

### DIFF
--- a/src/highOrder.C
+++ b/src/highOrder.C
@@ -126,12 +126,12 @@ void MeshBlock::getCellIblanks(void)
                 TRACEI(inode[m]);
                 TRACEI(ibl[inode[m]]);
               }
-	      if (ibl[inode[m]]==-1) 
+	      if (ibl[inode[m]]==0)
 		{
-		  iblank_cell[icell]=-1;
+		  iblank_cell[icell]=0;
 		  flag=0;
 		}
-	      ncount=ncount+(ibl[inode[m]]==0);
+	      ncount=ncount+(ibl[inode[m]]== -1);
 	    }
 	  if (verbose) {
 	    TRACEI(icell);
@@ -140,7 +140,7 @@ void MeshBlock::getCellIblanks(void)
            } 
 	  if (flag) 
 	    {
-	      if (ncount ==nvert) iblank_cell[icell]=0;
+	      if (ncount ==nvert) iblank_cell[icell]=-1;
 //	      if (ncount > 0)  iblank_cell[icell]=-1;
 //	      if (ncount >= nvert/2) iblank_cell[icell]=-1;
 	    }


### PR DESCRIPTION
Redo logic for `iblank_cell`

- Set to `1` if all the nodes are _field points_
- Set to `-1` if all the nodes are _fringe points_
- Set to `0` if any node is a _hole point_

Reverting back to the original behavior since we no longer use `iblank_cell` in [nalu-wind](https://github.com/exawind/nalu-wind/) to handle `inactive part`. The original behavior will minimize the amount of _gaps_ seen in viz with paraview. 