### PR TITLE
fixing counter length

### DIFF
--- a/src/exchangeAMRDonors.C
+++ b/src/exchangeAMRDonors.C
@@ -251,7 +251,7 @@ void tioga::exchangeAMRDonors(void)
       if (rcvPack[i].nints > 0) 
 	{
 	  m=0;
-	  for(j=0;j<rcvPack[i].nints/2;j++)
+	  for(j=0;j<rcvPack[i].nints/3;j++)
 	    {
 	      ctype=rcvPack[i].intData[m++];
 	      id=rcvPack[i].intData[m++];


### PR DESCRIPTION
This pull request fixes the counter length (currently resulting in a bad access error) based on how `intcount` is incremented in the immediately preceding lines.