### PR TITLE
introduce linear interpolation for cell-centered background mesh

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TIOGA_SOURCES
   getCartReceptors.C
   highOrder.C
   holeMap.C
+  linCartInterp.C
   parallelComm.C
   search.C
   searchADTrecursion.C

--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -164,6 +164,8 @@ void CartBlock::preprocess(CartGrid *cg)
     myid=cg->myid;
     qstride=cg->qstride;
     donor_frac=cg->donor_frac;
+    if((pdegree != 0) && (donor_frac == nullptr))
+      throw std::runtime_error("#tioga: Donor function required for pdegree > 0");
     qnode=cg->qnode;
     d1=dims[0];
     d2=dims[0]*dims[1];
@@ -250,8 +252,8 @@ void CartBlock::insertInInterpList(int procid,int remoteid,int remoteblockid,dou
     listptr->nweights=8;
     listptr->weights=(double *)malloc(sizeof(double)*listptr->nweights);
     listptr->inode=(int *)malloc(sizeof(int)*(listptr->nweights*3));
-    cart_interp::linear_interpolation(&pdegree,ix,dims,rst,&(listptr->nweights),
-      &(listptr->inode),&(listptr->weights));
+    cart_interp::linear_interpolation(1,ix,dims,rst,&(listptr->nweights),
+      listptr->inode,listptr->weights);
   }
   else {
     listptr->nweights=(pdegree+1)*(pdegree+1)*(pdegree+1);

--- a/src/CartBlock.h
+++ b/src/CartBlock.h
@@ -48,7 +48,8 @@ class CartBlock
   DONORLIST **donorList;
   void (*donor_frac) (int *,double *,int *,double *);
  public:
-  CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl=NULL;q=NULL;interpListSize=0;donorList=NULL;interpList=NULL;};
+  CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl=NULL;q=NULL;interpListSize=0;donorList=NULL;interpList=NULL;
+    donor_frac=nullptr;};
   ~CartBlock() { clearLists();};
   void registerData(int local_id_in,int global_id_in,int *iblankin,double *qin)
   {

--- a/src/CartGrid.h
+++ b/src/CartGrid.h
@@ -50,7 +50,7 @@ class CartGrid
    
   CartGrid() { ngrids=0;global_id=NULL;level_num=NULL;local_id=NULL;porder=NULL;
     proc_id=NULL;local_id=NULL;ilo=NULL;ihi=NULL;dims=NULL;
-               xlo=NULL;dx=NULL;dxlvl=NULL;lcount=NULL;qnode=NULL;};
+               xlo=NULL;dx=NULL;dxlvl=NULL;lcount=NULL;qnode=NULL;donor_frac=nullptr;};
   ~CartGrid() { 
     if (global_id) free(global_id);
     if (level_num) free(level_num);

--- a/src/linCartInterp.C
+++ b/src/linCartInterp.C
@@ -1,0 +1,149 @@
+//
+// This file is part of the Tioga software library
+//
+// Tioga  is a tool for overset grid assembly on parallel distributed systems
+// Copyright (C) 2015 Jay Sitaraman
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#include "linCartInterp.h"
+
+namespace cart_interp
+{
+void check_out_of_domain(int* dims, int nw, int** ijk_stencil, std::vector<double>& ref_coord)
+{
+  // adjust reference cooridnates to collapse dimensions if out of domain
+  for(int i=0;i<nw;i++)
+  {
+    if(ijk_stencil[0][3*i]>=dims[0])
+    {
+      ijk_stencil[0][3*i]=dims[0]-1;
+      ref_coord[0]=-1;
+    }
+    else if(ijk_stencil[0][3*i]<0)
+    {
+      ijk_stencil[0][3*i]=0;
+      ref_coord[0]=1;
+    }
+    if(ijk_stencil[0][3*i+1]>=dims[1])
+    {
+      ijk_stencil[0][3*i+1]=dims[1]-1;
+      ref_coord[1]=-1;
+    }
+    else if(ijk_stencil[0][3*i+1]<0)
+    {
+      ijk_stencil[0][3*i+1]=0;
+      ref_coord[1]=1;
+    }
+    if(ijk_stencil[0][3*i+2]>=dims[2])
+    {
+      ijk_stencil[0][3*i+2]=dims[2]-1;
+      ref_coord[2]=-1;
+    }
+    else if(ijk_stencil[0][3*i+2]<0)
+    {
+      ijk_stencil[0][3*i+2]=0;
+      ref_coord[2]=1;
+    }
+  }
+}
+
+void compute_linear_weights(const std::vector<double>& ref_coord, double** weights)
+{
+  double eta = ref_coord[0];
+  double mu  = ref_coord[1];
+  double xi  = ref_coord[2];
+
+  // assign weights based on shape functions for a FE brick element
+  weights[0][0] = (1-eta)*(1+mu)*(1-xi)/8;
+  weights[0][1] = (1-eta)*(1-mu)*(1-xi)/8;
+  weights[0][2] = (1-eta)*(1-mu)*(1+xi)/8;
+  weights[0][3] = (1-eta)*(1+mu)*(1+xi)/8;
+  weights[0][4] = (1+eta)*(1+mu)*(1-xi)/8;
+  weights[0][5] = (1+eta)*(1-mu)*(1-xi)/8;
+  weights[0][6] = (1+eta)*(1-mu)*(1+xi)/8;
+  weights[0][7] = (1+eta)*(1+mu)*(1+xi)/8;
+}
+
+void compute_ref_coords(double* ref_ratio, std::vector<double>& ref_coord)
+{
+  ref_coord[0] = (ref_ratio[0]-0.5>=0) ? ((ref_ratio[0]-0.5)*2-1) : ((ref_ratio[0]+0.5)*2-1);
+  ref_coord[1] = (ref_ratio[1]-0.5>=0) ? ((ref_ratio[1]-0.5)*2-1) : ((ref_ratio[1]+0.5)*2-1);
+  ref_coord[2] = (ref_ratio[2]-0.5>=0) ? ((ref_ratio[2]-0.5)*2-1) : ((ref_ratio[2]+0.5)*2-1);
+}
+
+void create_linear_donor_stencil(int* ijk_cell, double* ref_ratio, int** ijk_stencil)
+{
+  // determine if donor stencil is to right or left of the cell-center
+   ijk_stencil[0][0] = (ref_ratio[0]-0.5>=0) ? (ijk_cell[0]) : (ijk_cell[0]-1);
+
+   // determine if donor stencil is front of or behind the cell-center
+   ijk_stencil[0][1] = (ref_ratio[1]-0.5>=0) ? (ijk_cell[1]+1) : (ijk_cell[1]);
+
+   // determine if donor stencil is above or below the cell-center
+   ijk_stencil[0][2] = (ref_ratio[2]-0.5>=0) ? (ijk_cell[2]) : (ijk_cell[2]-1);
+
+   // node 2 of reference brick element
+   ijk_stencil[0][3]=ijk_stencil[0][0];
+   ijk_stencil[0][4]=ijk_stencil[0][1]-1;
+   ijk_stencil[0][5]=ijk_stencil[0][2];
+
+   // node 3 of reference brick element
+   ijk_stencil[0][6]=ijk_stencil[0][0];
+   ijk_stencil[0][7]=ijk_stencil[0][1]-1;
+   ijk_stencil[0][8]=ijk_stencil[0][2]+1;
+
+   // node 4 of reference brick element
+   ijk_stencil[0][9] =ijk_stencil[0][0];
+   ijk_stencil[0][10]=ijk_stencil[0][1];
+   ijk_stencil[0][11]=ijk_stencil[0][2]+1;
+
+   // node 5 of reference brick element
+   ijk_stencil[0][12]=ijk_stencil[0][0]+1;
+   ijk_stencil[0][13]=ijk_stencil[0][1];
+   ijk_stencil[0][14]=ijk_stencil[0][2];
+
+   // node 6 of reference brick element
+   ijk_stencil[0][15]=ijk_stencil[0][0]+1;
+   ijk_stencil[0][16]=ijk_stencil[0][1]-1;
+   ijk_stencil[0][17]=ijk_stencil[0][2];
+
+   // node 7 of reference brick element
+   ijk_stencil[0][18]=ijk_stencil[0][0]+1;
+   ijk_stencil[0][19]=ijk_stencil[0][1]-1;
+   ijk_stencil[0][20]=ijk_stencil[0][2]+1;
+
+   // node 8 of reference brick element
+   ijk_stencil[0][21]=ijk_stencil[0][0]+1;
+   ijk_stencil[0][22]=ijk_stencil[0][1];
+   ijk_stencil[0][23]=ijk_stencil[0][2]+1;
+}
+
+void linear_interpolation(int* pdegree, int* ijk_cell, int* dims, double* ref_ratio,
+  int* nw, int** ijk_stencil, double** weights)
+{
+  if(*pdegree != 0)
+    throw std::runtime_error("#tioga: linear Cartesian interpolation not setup for pdegree > 0");
+
+  std::vector<double> ref_coord(3,0); // array of reference coordinates
+
+  // 8-node donor stencil where the nodes are neighboring cell-centers
+  // ordering of cell centers in donor stencil is such that
+  // left->right is along x-axis. back->front is along y-axis. bottom->top is along z-axis
+  create_linear_donor_stencil(ijk_cell,ref_ratio,ijk_stencil);
+  compute_ref_coords(ref_ratio,ref_coord);
+  check_out_of_domain(dims,*nw,ijk_stencil,ref_coord);
+  compute_linear_weights(ref_coord,weights);
+}
+}

--- a/src/linCartInterp.h
+++ b/src/linCartInterp.h
@@ -1,0 +1,39 @@
+//
+// This file is part of the Tioga software library
+//
+// Tioga  is a tool for overset grid assembly on parallel distributed systems
+// Copyright (C) 2015 Jay Sitaraman
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#include <vector>
+
+#ifndef LINCARTINTERP_H
+#define LINCARTINTERP_H
+
+namespace cart_interp
+{
+void check_out_of_domain(int* dims, int nw, int** ijk_stencil, std::vector<double>& ref_coord);
+
+void compute_linear_weights(const std::vector<double>& ref_coord, double** weights);
+
+void compute_ref_coords(double* ref_ratio, std::vector<double>& ref_coord);
+
+void create_linear_donor_stencil(int* ijk_cell, double* ref_ratio, int** ijk_stencil);
+
+void linear_interpolation(int* pdegree, int* ijk_cell, int* dims, double* ref_ratio,
+  int* nw, int** ijk_stencil, double** weights);
+} // namespacee cart_interp
+
+#endif /* LINCARTINTERP_H */

--- a/src/linCartInterp.h
+++ b/src/linCartInterp.h
@@ -24,16 +24,17 @@
 
 namespace cart_interp
 {
-void check_out_of_domain(int* dims, int nw, int** ijk_stencil, std::vector<double>& ref_coord);
+void compute_1d_bases(const int& p, const std::vector<double>& ref_coord,
+  std::vector<double>& phi_x, std::vector<double>& phi_y, std::vector<double>& phi_z);
 
-void compute_linear_weights(const std::vector<double>& ref_coord, double** weights);
+void compute_linear_weights(const std::vector<double>& ref_coord, double* weights);
 
 void compute_ref_coords(double* ref_ratio, std::vector<double>& ref_coord);
 
-void create_linear_donor_stencil(int* ijk_cell, double* ref_ratio, int** ijk_stencil);
+void create_donor_stencil(const int& p, int* ijk_cell, int* dims, double* ref_ratio, int* ijk_stencil);
 
-void linear_interpolation(int* pdegree, int* ijk_cell, int* dims, double* ref_ratio,
-  int* nw, int** ijk_stencil, double** weights);
+void linear_interpolation(const int& p, int* ijk_cell, int* dims, double* ref_ratio,
+  int* nw, int* ijk_stencil, double* weights);
 } // namespacee cart_interp
 
 #endif /* LINCARTINTERP_H */


### PR DESCRIPTION
This pull request introduces linear interpolation for the background Cartesian mesh where the solution is cell-centered. The linear interpolation is used by default if `(donor_frac == nullptr) && (pdegree == 0)`. The interpolation is modeled after a FE brick element where the nodes are neighboring cell centers. 