### PR TITLE
create accessor function to register solution for cartesian meshes

### DIFF
--- a/src/CartBlock.h
+++ b/src/CartBlock.h
@@ -51,13 +51,13 @@ class CartBlock
   CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl=NULL;q=NULL;interpListSize=0;donorList=NULL;interpList=NULL;
     donor_frac=nullptr;};
   ~CartBlock() { clearLists();};
-  void registerData(int local_id_in,int global_id_in,int *iblankin,double *qin)
+  void registerData(int local_id_in,int global_id_in,int *iblankin)
   {
     local_id=local_id_in;
     global_id=global_id_in;
     ibl=iblankin;
-    q=qin;
   };
+  void registerSolution(double *qin, bool isnodal) {q=qin;};
   void preprocess(CartGrid *cg);
   void getInterpolatedData(int *nints,int *nreals,int **intData,
 			   double **realData,

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -707,9 +707,14 @@ void tioga::set_amr_patch_count(int npatchesin)
   cb=new CartBlock[ncart];
 }
 
-void tioga::register_amr_local_data(int ipatch,int global_id,int *iblank,double *q)
+void tioga::register_amr_local_data(int ipatch,int global_id,int *iblank)
 {
-  cb[ipatch].registerData(ipatch,global_id,iblank,q);
+  cb[ipatch].registerData(ipatch,global_id,iblank);
+}
+
+void tioga::register_amr_solution(int ipatch,double *q,bool isnodal)
+{
+  cb[ipatch].registerSolution(q,isnodal);
 }
 
 #ifdef TIOGA_ENABLE_TIMERS

--- a/src/tioga.h
+++ b/src/tioga.h
@@ -249,7 +249,8 @@ class tioga
 
   void register_amr_global_data(int, int, double *, int *,double *, int, int);
   void set_amr_patch_count(int);
-  void register_amr_local_data(int, int ,int *, double *);  
+  void register_amr_local_data(int, int ,int *);
+  void register_amr_solution(int ,double *, bool);
   void exchangeAMRDonors(void);
   void checkComm(void);
   void outputStatistics(void);

--- a/src/tiogaInterface.C
+++ b/src/tiogaInterface.C
@@ -142,9 +142,14 @@ extern "C" {
     tg->set_amr_patch_count(*npatches);
   }
 
-  void tioga_register_amr_local_data_(int *ipatch,int *global_id,int *iblank,double *q)
+  void tioga_register_amr_local_data_(int *ipatch,int *global_id,int *iblank)
   {
-    tg->register_amr_local_data(*ipatch,*global_id,iblank,q);
+    tg->register_amr_local_data(*ipatch,*global_id,iblank);
+  }
+
+  void tioga_register_amr_solution_(int *ipatch,double *q, bool isnodal)
+  {
+    tg->register_amr_solution(*ipatch,q,isnodal);
   }
 
   void tioga_preprocess_grids_(void)


### PR DESCRIPTION
This pull request creates an accessor function to register the solution for cartesian meshes. A boolean `isnodal` is introduced to keep track of whether the solution array corresponds to solution living on node or cell centers.