### PR TITLE
Revert "Complete removal of get_amr_index_xyz and left-over porder-related variables"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TIOGA_SOURCES
   buildADTrecursion.c
   linklist.c
   math.c
+  get_amr_index_xyz.c
   utils.c
 
   # CXX sources

--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -29,14 +29,22 @@ extern "C" {
   void deallocateLinkList3(INTEGERLIST2 *temp);
   void deallocateLinkList4(INTERPLIST2 *temp);
   void insertInList(DONORLIST **donorList,DONORLIST *temp1);
-  int checkHoleMap(double *x,int *nx,int *sam,double *extents);
+  void get_amr_index_xyz(int i,int j,int k,
+			  int nX,int nY,int nZ,
+			  int nf,
+			  double xlo[3],double dx[3],
+			  int* index, double* xyz);
+    void amr_index_to_ijklmn(int nX,int nY,int nZ, int nf,
+			     int index, int* ijklmn);
+    int checkHoleMap(double *x,int *nx,int *sam,double *extents);
 }
 void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 				    double **realData,
 				    int nvar)
 {
   int i,n;
-  int index;
+  double *xtmp;
+  int *index;
   double *qq;
   int *tmpint;
   double *tmpreal;
@@ -77,6 +85,8 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
       listptr=interpList;
       icount=3*nintold;
       dcount=nrealold;
+      xtmp=(double *)malloc(sizeof(double)*3);
+      index=(int *)malloc(sizeof(int)*1);
       qq=(double *)malloc(sizeof(double)*nvar);
       while(listptr!=NULL)
       {
@@ -88,15 +98,13 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 
         for(i=0;i<listptr->nweights;i++)
         {
-          //Q[nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Cell storage
-          index = (dims[1]+2*nf)*(dims[0]+2*nf)*(listptr->inode[3*i+2]+nf)
-              + (dims[0]+2*nf)*(listptr->inode[3*i+1]+nf)
-              + (listptr->inode[3*i]+nf);
-
+          get_amr_index_xyz(listptr->inode[3*i],listptr->inode[3*i+1],listptr->inode[3*i+2],
+            dims[0],dims[1],dims[2],nf,
+            xlo,dx,index,xtmp);
           for(n=0;n<nvar;n++)
           {
             weight=listptr->weights[i];
-            qq[n]+=qcell[index+d3nf*n]*weight;
+            qq[n]+=qcell[index[0]+d3nf*n]*weight;
           }
         }
 
@@ -104,6 +112,8 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 
         listptr=listptr->next;
       }
+      TIOGA_FREE(xtmp);
+      TIOGA_FREE(index);
       TIOGA_FREE(qq);
     }
 }
@@ -223,8 +233,19 @@ void CartBlock::insertInDonorList(int senderid,int index,int meshtagdonor,int re
 {
   DONORLIST *temp1;
   int ijklmn[6];
+  int pointid;
   temp1=(DONORLIST *)malloc(sizeof(DONORLIST));
-  if (!(index >= 0 && index < ndof)) {
+  amr_index_to_ijklmn(dims[0],dims[1],dims[2],nf,index,ijklmn);
+  //pointid=ijklmn[5]*(pdegree+1)*(pdegree+1)*d3+
+  //        ijklmn[4]*(pdegree+1)*d3+
+  //        ijklmn[3]*d3+
+  //        ijklmn[2]*d2+
+  //        ijklmn[1]*d1+
+  //        ijklmn[0];
+  pointid=(ijklmn[2]*d2+ijklmn[1]*d1+ijklmn[0])+
+           ijklmn[5]+
+           ijklmn[4]+ijklmn[3];
+  if (!(pointid >= 0 && pointid < ndof)) {
     TRACEI(index);
     TRACEI(nf);
     TRACEI(dims[0]);
@@ -233,7 +254,7 @@ void CartBlock::insertInDonorList(int senderid,int index,int meshtagdonor,int re
     printf("%d %d %d %d %d %d\n",ijklmn[0],ijklmn[1],ijklmn[2],
 	   ijklmn[3],ijklmn[4],ijklmn[5]);
   }
-  assert((index >= 0 && index < ndof));
+  assert((pointid >= 0 && pointid < ndof));
     
   temp1->donorData[0]=senderid;
   temp1->donorData[1]=meshtagdonor;
@@ -241,7 +262,7 @@ void CartBlock::insertInDonorList(int senderid,int index,int meshtagdonor,int re
   temp1->donorData[3]=remoteblockid;
   temp1->donorRes=cellRes;
   temp1->cancel=0;
-  insertInList(&(donorList[index]),temp1);
+  insertInList(&(donorList[pointid]),temp1);
 }
 
 void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
@@ -252,6 +273,7 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
   int *iflag;
   int holeFlag;
   double *xtmp;
+  int *index;
   int ibindex;
   //FILE*fp;
   char fname[80];
@@ -273,6 +295,7 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
   // first mark hole points
   //
   iflag=(int *)malloc(sizeof(int)*nmesh);
+  index=(int *)malloc(sizeof(int)*1);
   xtmp=(double *)malloc(sizeof(double)*3);
   //
   ibcount=-1;
@@ -284,10 +307,8 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
       for(i=0;i<dims[0];i++)
 	{
 	  ibcount++;
-    xtmp[0] = xlo[0] + (i+0.5)*dx[0];
-    xtmp[1] = xlo[1] + (j+0.5)*dx[1];
-    xtmp[2] = xlo[2] + (k+0.5)*dx[2];
-
+	  get_amr_index_xyz(i,j,k,dims[0],dims[1],dims[2],nf,
+			    xlo,dx,index,xtmp);
           holeFlag=1;
           idof=ibcount-1;
 	    {
@@ -341,7 +362,8 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
 	{
 	  ibcount++;
           ibindex=(k+nf)*(dims[1]+2*nf)*(dims[0]+2*nf)+(j+nf)*(dims[0]+2*nf)+i+nf;
-
+          get_amr_index_xyz(i,j,k,dims[0],dims[1],dims[2],nf,
+                            xlo,dx,index,xtmp);
 	  if (ibl[ibindex]==0) 
 	    {
               idof=ibcount-1;
@@ -382,6 +404,8 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
 	      if (icount==1)
 		{
 		  ibl[ibindex]=-1;
+                  //for(p=0;p<p3;p++)
+	          // fprintf(fp,"%f %f %f\n",xtmp[3*p],xtmp[3*p+1],xtmp[3*p+2]);
 		}
 	      else
 		{
@@ -433,6 +457,7 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
 
   if (iflag) TIOGA_FREE(iflag);
   if (xtmp)  TIOGA_FREE(xtmp);
+  if (index) TIOGA_FREE(index);
   // fclose(fp);
 }
 			      

--- a/src/get_amr_index_xyz.c
+++ b/src/get_amr_index_xyz.c
@@ -1,0 +1,106 @@
+void get_amr_index_xyz(int i,int j,int k,
+			int nX,int nY,int nZ,
+			int nf,
+			double *xlo,double *dx,
+			int* index, double* xyz){
+        
+  int base;
+  int starting_entry;
+        
+  int ind = 0;               
+  int two_nf = 2*nf;
+  int qp_1d = 1;
+        
+  int grid_stride = (nX + two_nf)*(nY + two_nf)*(nZ + two_nf);
+  int z_stride = grid_stride*(qp_1d*qp_1d);
+  int y_stride = grid_stride*(qp_1d);
+        
+  double cell_xlo = xlo[0] + i*dx[0];
+  double cell_ylo = xlo[1] + j*dx[1];
+  double cell_zlo = xlo[2] + k*dx[2];
+        
+  double half_dx = 0.5*dx[0];
+  double half_dy = 0.5*dx[1];
+  double half_dz = 0.5*dx[2];
+        
+  double yco = 0.0;
+  double zco = 0.0;
+  int x,y,z;
+                
+  //Q[p+1,p+1,p+1,nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Storage
+  starting_entry = (nY+two_nf)*(nX+two_nf)*(k+nf)
+    + (nX+two_nf)*(j+nf)
+    + (i+nf);
+        
+  for (z = 0;z < qp_1d;z++){
+    zco = cell_zlo + half_dz;
+    for (y = 0;y < qp_1d;y++){
+      yco = cell_ylo + half_dy;
+      for ( x = 0;x < qp_1d;x++){                    
+                    index[ind] = starting_entry
+		      + z_stride*(z)
+		      + y_stride*(y)
+		      + grid_stride*(x);
+                                                            
+                    base = 3*ind;
+                    xyz[base]   = cell_xlo + half_dx;
+                    xyz[base+1] = yco;
+                    xyz[base+2] = zco;
+                    
+                    ind++;
+      }
+    }
+  }
+}
+
+void amr_index_to_ijklmn(int nX,int nY,int nZ, int nf,
+			 int index, int* ijklmn)
+{
+        
+  //Q[p+1,p+1,p+1,nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Storage
+
+  int remainder;
+
+  int two_nf = 2*nf;
+  int qp_1d = 1;
+
+  int x_size = (nX + two_nf);
+  int y_size = (nY + two_nf);
+  int z_size = (nZ + two_nf);
+
+  int xy_stride = x_size*y_size;
+  int xyz_stride = xy_stride*z_size;
+
+  int grid_stride = x_size*y_size*z_size;
+  int x_stride = grid_stride;
+  int y_stride = grid_stride*(qp_1d);
+  int z_stride = grid_stride*(qp_1d*qp_1d);
+
+  remainder = index;
+  int n = index / z_stride;
+  remainder = index % z_stride;
+
+  int m = remainder / y_stride;
+  remainder %= y_stride;                
+
+  int l = remainder / x_stride;
+  remainder %= x_stride;
+
+  //Skip fields
+  remainder %= xyz_stride;
+
+  int k = remainder / xy_stride;
+  remainder %= xy_stride;
+
+  int j = remainder / x_size;
+  remainder %= x_size;
+
+  int i = remainder;
+
+  ijklmn[0] = i-nf;
+  ijklmn[1] = j-nf;
+  ijklmn[2] = k-nf;
+  ijklmn[3] = l;
+  ijklmn[4] = m;
+  ijklmn[5] = n;    
+}

--- a/src/test_amr_functions.c
+++ b/src/test_amr_functions.c
@@ -1,0 +1,151 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void get_amr_index_xyz( int nq,int i,int j,int k,
+			int pBasis,
+			int nX,int nY,int nZ,
+			int nf,
+			double *xlo,double *dx,
+			double qnodes[],
+			int* index, double* xyz){
+        
+  int base;
+  int starting_entry;
+        
+  int ind = 0;               
+  int two_nf = 2*nf;
+  int qp_1d = pBasis + 1;  
+        
+  int grid_stride = nq*(nX + two_nf)*(nY + two_nf)*(nZ + two_nf);
+  int z_stride = grid_stride*(qp_1d*qp_1d);
+  int y_stride = grid_stride*(qp_1d);
+        
+  double cell_xlo = xlo[0] + i*dx[0];
+  double cell_ylo = xlo[1] + j*dx[1];
+  double cell_zlo = xlo[2] + k*dx[2];
+        
+  double half_dx = 0.5*dx[0];
+  double half_dy = 0.5*dx[1];
+  double half_dz = 0.5*dx[2];
+        
+  double yco = 0.0;
+  double zco = 0.0;
+  int x,y,z;
+                
+  //Q[p+1,p+1,p+1,nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Storage
+  starting_entry = (nY+two_nf)*(nX+two_nf)*(k+nf)
+    + (nX+two_nf)*(j+nf)
+    + (i+nf);
+        
+  for (z = 0;z < qp_1d;z++){
+    zco = cell_zlo + half_dz*(1.0 + qnodes[z]);
+    for (y = 0;y < qp_1d;y++){
+      yco = cell_ylo + half_dy*(1.0 + qnodes[y]);
+      for ( x = 0;x < qp_1d;x++){                    
+                    index[ind] = starting_entry
+		      + z_stride*(z)
+		      + y_stride*(y)
+		      + grid_stride*(x);
+                                                            
+                    base = 3*ind;
+                    xyz[base]   = cell_xlo + half_dx*(1.0 + qnodes[x]);
+                    xyz[base+1] = yco;
+                    xyz[base+2] = zco;
+                    
+                    ind++;
+      }
+    }
+  }
+}
+
+void amr_index_to_ijklmn(int pBasis,int nX,int nY,int nZ, int nf, int nq,
+			 int index, int* ijklmn)
+{
+        
+  //Q[p+1,p+1,p+1,nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Storage
+
+  int remainder;
+
+  int two_nf = 2*nf;
+  int qp_1d = pBasis + 1;  
+
+  int x_size = (nX + two_nf);
+  int y_size = (nY + two_nf);
+  int z_size = (nZ + two_nf);
+
+  int xy_stride = x_size*y_size;
+  int xyz_stride = xy_stride*z_size;
+
+  int grid_stride = nq*x_size*y_size*z_size;
+  int x_stride = grid_stride;
+  int y_stride = grid_stride*(qp_1d);
+  int z_stride = grid_stride*(qp_1d*qp_1d);
+
+  remainder = index;
+  int n = index / z_stride;
+  remainder = index % z_stride;
+
+  int m = remainder / y_stride;
+  remainder %= y_stride;                
+
+  int l = remainder / x_stride;
+  remainder %= x_stride;
+
+  //Skip fields
+  remainder %= xyz_stride;
+
+  int k = remainder / xy_stride;
+  remainder %= xy_stride;
+
+  int j = remainder / x_size;
+  remainder %= x_size;
+
+  int i = remainder;
+
+  ijklmn[0] = i-nf;
+  ijklmn[1] = j-nf;
+  ijklmn[2] = k-nf;
+  ijklmn[3] = l;
+  ijklmn[4] = m;
+  ijklmn[5] = n;    
+}
+
+void main(void)
+{
+  int i;
+  int index =301;
+  int nf =1;
+  int pdegree =1;
+  int nX =4;
+  int nY=2;
+  int nZ =4;
+  int qstride =5;
+  int *ijklmn;
+  double *qnodes;
+  int *index1;
+  double *xlo;
+  double *dx;
+  double *xyz;
+
+  xlo=(double *)malloc(sizeof(double)*3);
+  dx=(double *)malloc(sizeof(double)*3);
+  index1=(int *)malloc(sizeof(int)*8);
+  qnodes=(double *)malloc(sizeof(double)*2);
+  xyz=(double *)malloc(sizeof(double)*8*3);
+  for(i=0;i<3;i++)
+    {
+      xlo[i]=0.0;
+      dx[i]=1.0;
+    }
+  qnodes[0]=-sqrt(1./3.0);
+  qnodes[1]=-qnodes[0];  
+  ijklmn=(int *)malloc(sizeof(int)*6);  
+  get_amr_index_xyz(qstride,0,0,0,pdegree,nX,nY,nZ,nf,xlo,dx,qnodes,index1,xyz);
+  for(i=0;i<8;i++) printf("%d ",index1[i]);
+  printf("\n");
+  for(i=0;i<8;i++)
+    {
+      amr_index_to_ijklmn(pdegree,nX,nY,nZ,nf,qstride,index1[i],ijklmn);
+      printf("%d %d %d %d %d %d\n",ijklmn[0],ijklmn[1],ijklmn[2],ijklmn[3],ijklmn[4],ijklmn[5]);
+    }
+}


### PR DESCRIPTION
Reverts jsitaraman/tioga#25

This commit breaks AMR connectivity when `nf > 0`