### PR TITLE
Adding code to introduce nodes for background mesh

### DIFF
--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -20,6 +20,7 @@
 #include "codetypes.h"
 #include "CartBlock.h"
 #include "CartGrid.h"
+#include "cartUtils.h"
 #include "linCartInterp.h"
 #include <assert.h>
 #include <stdexcept>
@@ -88,10 +89,8 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 
         for(i=0;i<listptr->nweights;i++)
         {
-          //Q[nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Cell storage
-          index = (dims[1]+2*nf)*(dims[0]+2*nf)*(listptr->inode[3*i+2]+nf)
-              + (dims[0]+2*nf)*(listptr->inode[3*i+1]+nf)
-              + (listptr->inode[3*i]+nf);
+          index = cart_utils::get_cell_index(dims[0],dims[1],nf,
+            listptr->inode[3*i],listptr->inode[3*i+1],listptr->inode[3*i+2]);
 
           for(n=0;n<nvar;n++)
           {
@@ -317,8 +316,8 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
 		      {
 			if (checkHoleMap(xtmp,holemap[h].nx,holemap[h].sam,holemap[h].extents))
 			  {
-	                    ibindex=(k+nf)*(dims[1]+2*nf)*(dims[0]+2*nf)+(j+nf)*(dims[0]+2*nf)+i+nf;
-			    ibl[ibindex]=0;
+        ibindex=cart_utils::get_cell_index(dims[0],dims[1],nf,i,j,k);
+        ibl[ibindex]=0;
                             holeFlag=0;
 			    break;
 			  }
@@ -341,7 +340,7 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
 			  if (!iflag[h])
 			    if (checkHoleMap(xtmp,holemap[h].nx,holemap[h].sam,holemap[h].extents))
 			      {
-	                        ibindex=(k+nf)*(dims[1]+2*nf)*(dims[0]+2*nf)+(j+nf)*(dims[0]+2*nf)+i+nf;
+			      ibindex=cart_utils::get_cell_index(dims[0],dims[1],nf,i,j,k);
 				ibl[ibindex]=0;
                                 holeFlag=0;
 				break;
@@ -358,7 +357,7 @@ void CartBlock::processDonors(HOLEMAP *holemap, int nmesh)
       for(i=0;i<dims[0];i++)
 	{
 	  ibcount++;
-          ibindex=(k+nf)*(dims[1]+2*nf)*(dims[0]+2*nf)+(j+nf)*(dims[0]+2*nf)+i+nf;
+	  ibindex=cart_utils::get_cell_index(dims[0],dims[1],nf,i,j,k);
 
 	  if (ibl[ibindex]==0) 
 	    {

--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -111,11 +111,8 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 
 void CartBlock::update(double *qval, int index,int nq)
 {
-  if(index >= ncell_nf){
-    int stop = 0;
-    stop = stop -1;
+  if(index >= ncell_nf)
     return;
-  }
 
   int i;
   for(i=0;i<nq;i++)

--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -111,6 +111,12 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 
 void CartBlock::update(double *qval, int index,int nq)
 {
+  if(index >= ncell_nf){
+    int stop = 0;
+    stop = stop -1;
+    return;
+  }
+
   int i;
   for(i=0;i<nq;i++)
     qcell[index+ncell_nf*i]=qval[i];
@@ -223,6 +229,9 @@ void CartBlock::insertInInterpList(int procid,int remoteid,int remoteblockid,dou
   
 void CartBlock::insertInDonorList(int senderid,int index,int meshtagdonor,int remoteid,int remoteblockid, double cellRes)
 {
+  if(index >= ncell_nf)
+    return;
+
   DONORLIST *temp1;
   int i,j,k,x_stride,xy_stride;
   int pointid;

--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -96,7 +96,7 @@ void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
           for(n=0;n<nvar;n++)
           {
             weight=listptr->weights[i];
-            qq[n]+=qcell[index+d3nf*n]*weight;
+            qq[n]+=qcell[index+ncell_nf*n]*weight;
           }
         }
 
@@ -113,7 +113,7 @@ void CartBlock::update(double *qval, int index,int nq)
 {
   int i;
   for(i=0;i<nq;i++)
-    qcell[index+d3nf*i]=qval[i];
+    qcell[index+ncell_nf*i]=qval[i];
 }
 
   
@@ -131,21 +131,23 @@ void CartBlock::preprocess(CartGrid *cg)
     d1=dims[0];
     d2=dims[0]*dims[1];
     d3=d2*dims[2];
-    d3nf=(dims[0]+2*nf)*(dims[1]+2*nf)*(dims[2]+2*nf);
-    ndof=d3;
+    ncell=d3;
+    ncell_nf=(dims[0]+2*nf)*(dims[1]+2*nf)*(dims[2]+2*nf);
+    nnode=(d1+1)*(d2+1)*(d3+1);
+    nnode_nf=(dims[0]+1+2*nf)*(dims[1]+1+2*nf)*(dims[2]+1+2*nf);
   };
 
 void CartBlock::initializeLists(void)
 {
- donorList=(DONORLIST **)malloc(sizeof(DONORLIST *)*ndof);
- for(int i=0;i<ndof;i++) donorList[i]=NULL;
+ donorList=(DONORLIST **)malloc(sizeof(DONORLIST *)*ncell);
+ for(int i=0;i<ncell;i++) donorList[i]=NULL;
 }
 
 void CartBlock::clearLists(void)
 {
   int i;
   if (donorList) {
-  for(i=0;i<ndof;i++) { deallocateLinkList(donorList[i]); donorList[i]=NULL;}
+  for(i=0;i<ncell;i++) { deallocateLinkList(donorList[i]); donorList[i]=NULL;}
   TIOGA_FREE(donorList);
   }
   deallocateLinkList4(interpList);
@@ -236,14 +238,14 @@ void CartBlock::insertInDonorList(int senderid,int index,int meshtagdonor,int re
   i = index;
   pointid=(k-nf)*d2+(j-nf)*d1+(i-nf);
 
-  if (!(pointid >= 0 && pointid < ndof)) {
+  if (!(pointid >= 0 && pointid < ncell)) {
     TRACEI(index);
     TRACEI(nf);
     TRACEI(dims[0]);
     TRACEI(dims[1]);
     TRACEI(dims[2]);
   }
-  assert((pointid >= 0 && pointid < ndof));
+  assert((pointid >= 0 && pointid < ncell));
     
   temp1->donorData[0]=senderid;
   temp1->donorData[1]=meshtagdonor;

--- a/src/CartBlock.h
+++ b/src/CartBlock.h
@@ -34,8 +34,8 @@ class CartBlock
  private:
   int local_id;
   int global_id;
-  int dims[3],nf,ndof;
-  int d1,d2,d3,d3nf;
+  int dims[3],nf,ncell,ncell_nf,nnode,nnode_nf;
+  int d1,d2,d3;
   int myid;
   int *ibl;
   double *qcell, *qnode;

--- a/src/MeshBlock.h
+++ b/src/MeshBlock.h
@@ -312,6 +312,8 @@ class MeshBlock
   void clearOrphans(HOLEMAP *holemap,int nmesh,int *itmp);
   void getUnresolvedMandatoryReceptors();
   void getCartReceptors(CartGrid *cg, parallelComm *pc);
+  void fillReceptorDataPtr(CartGrid *cg,int cell_count,int c,int j,int k,int l,int* pmap,
+    double vol,double* xtm,bool isNodal,INTEGERLIST2*& dataPtr);
   void setCartIblanks(void);
   
   // Getters

--- a/src/cartUtils.h
+++ b/src/cartUtils.h
@@ -1,0 +1,40 @@
+//
+// This file is part of the Tioga software library
+//
+// Tioga  is a tool for overset grid assembly on parallel distributed systems
+// Copyright (C) 2015 Jay Sitaraman
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#ifndef CARTUTILS_H
+#define CARTUTILS_H
+
+namespace cart_utils
+{
+  //Q[nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Cell storage
+  inline int get_cell_index(int nX,int nY,int nf,int i,int j,int k)
+  {
+    return (nY+2*nf)*(nX+2*nf)*(k+nf) + (nX+2*nf)*(j+nf) + (i+nf);
+  }
+
+  //Q[nq,nZ+1+2*nf,nY+1+2*nf,nX+1+2*nf]--> C++ node storage
+  // node index is assumed to follow cell index
+  inline int get_node_index(int nX,int nY,int nZ,int nf,int i,int j,int k)
+  {
+    return (nY+1+2*nf)*(nX+1+2*nf)*(k+nf) + (nX+1+2*nf)*(j+nf) + (i+nf)
+        + (nX+2*nf)*(nY+2*nf)*(nZ+2*nf);
+  }
+} // namespacee cart_utils
+
+#endif /* CARTUTILS_H */

--- a/src/getCartReceptors.C
+++ b/src/getCartReceptors.C
@@ -26,6 +26,7 @@
 #include "MeshBlock.h"
 #include "parallelComm.h"
 #include "CartGrid.h"
+#include "cartUtils.h"
 extern "C"{
   int obbIntersectCheck(double vA[3][3],double xA[3],double dxA[3],
                         double vB[3][3],double xB[3],double dxB[3]);
@@ -157,22 +158,22 @@ void MeshBlock::fillReceptorDataPtr(CartGrid *cg,int cell_count,int c,int j,int 
 {
   int itm = -1;
   if(isNodal){
-    itm = (cg->dims[3*c+1]+1+2*cg->nf)*(cg->dims[3*c]+1+2*cg->nf)*(l+cg->nf)
-        + (cg->dims[3*c]+1+2*cg->nf)*(k+cg->nf) + (j+cg->nf)
-        + cell_count;
+    itm = cart_utils::get_node_index(cg->dims[3*c],cg->dims[3*c+1],cg->dims[3*c+2],
+      cg->nf,j,k,l);
 
     xtm[0] = cg->xlo[3*c]   + j*cg->dx[3*c];
     xtm[1] = cg->xlo[3*c+1] + k*cg->dx[3*c+1];
     xtm[2] = cg->xlo[3*c+2] + l*cg->dx[3*c+2];
   }
   else {
-    itm = (cg->dims[3*c+1]+2*cg->nf)*(cg->dims[3*c]+2*cg->nf)*(l+cg->nf)
-        + (cg->dims[3*c]+2*cg->nf)*(k+cg->nf) + (j+cg->nf);
+    itm = cart_utils::get_cell_index(cg->dims[3*c],cg->dims[3*c+1],
+      cg->nf,j,k,l);
 
     xtm[0] = cg->xlo[3*c]   + (j+0.5)*cg->dx[3*c];
     xtm[1] = cg->xlo[3*c+1] + (k+0.5)*cg->dx[3*c+1];
     xtm[2] = cg->xlo[3*c+2] + (l+0.5)*cg->dx[3*c+2];
   }
+
 
   double xd[3];
   for(int jj=0;jj<3;jj++) xd[jj]=0;

--- a/src/getCartReceptors.C
+++ b/src/getCartReceptors.C
@@ -34,36 +34,17 @@ extern "C"{
 
 void MeshBlock::getCartReceptors(CartGrid *cg,parallelComm *pc)
 {
-  int i,j,k,l,m,c,n,itm,jj,kk;
-  int i3;
-  int iflag;
-  int icount,dcount,cell_count;
-  int nsend,nrecv;
-  int *pmap;
-  int *sndMap,*rcvMap;
-  OBB *obcart;
   INTEGERLIST2 *head;
   INTEGERLIST2 *dataPtr;
-  double *xtm;
-  double xd[3],vol;
-  //char qstr[2];
-  //char fname[80];
-  //char intstring[7];
-  //FILE *fp;
-  int intersectCount=0;
-
-  //sprintf(intstring,"%d",100000+myid);
-  //sprintf(fname,"zsearch_%s.dat",&(intstring[1]));
-  //fp=fopen(fname,"w");
   //
   // limit case we communicate to everybody
   //
-  pmap=(int *)malloc(sizeof(int)*pc->numprocs);
-  for(i=0;i<pc->numprocs;i++) pmap[i]=0;
+  int* pmap=(int *)malloc(sizeof(int)*pc->numprocs);
+  for(int i=0;i<pc->numprocs;i++) pmap[i]=0;
   //
-  obcart=(OBB *)malloc(sizeof(OBB));
-  for(j=0;j<3;j++)
-    for(k=0;k<3;k++)
+  OBB* obcart=(OBB *)malloc(sizeof(OBB));
+  for(int j=0;j<3;j++)
+    for(int k=0;k<3;k++)
       obcart->vec[j][k]=0;
   obcart->vec[0][0]=obcart->vec[1][1]=obcart->vec[2][2]=1.0;
   //
@@ -75,161 +56,60 @@ void MeshBlock::getCartReceptors(CartGrid *cg,parallelComm *pc)
   //
   nsearch=0;
   //
-  //writeOBB(myid);
-  //
-  for(c=0;c<cg->ngrids;c++)
+  for(int c=0;c<cg->ngrids;c++)
   {
-    cell_count = (cg->dims[3*c]+2*cg->nf)
-        * (cg->dims[3*c+1]+2*cg->nf)
-        * (cg->dims[3*c+2]+2*cg->nf);
+    int cell_count = (cg->dims[3*c]+2*cg->nf)
+                * (cg->dims[3*c+1]+2*cg->nf)
+                * (cg->dims[3*c+2]+2*cg->nf);
 
-    vol = cg->dx[3*c]*cg->dx[3*c+1]*cg->dx[3*c+2];
+    int vol = cg->dx[3*c]*cg->dx[3*c+1]*cg->dx[3*c+2];
 
-    for(n=0;n<3;n++)
-	{
-	  obcart->dxc[n]=cg->dx[3*c+n]*(cg->dims[3*c+n])*0.5;
-	  obcart->xc[n]=cg->xlo[3*c+n]+obcart->dxc[n];
-	}
-      if (obbIntersectCheck(obb->vec,obb->xc,obb->dxc,
-			    obcart->vec,obcart->xc,obcart->dxc) ||
-	  obbIntersectCheck(obcart->vec,obcart->xc,obcart->dxc,
-			    obb->vec,obb->xc,obb->dxc))
-	{
-	  intersectCount++;
-          //if (myid==0 && intersectCount==0) writeOBB2(obcart,c);
-           
-	  xtm=(double *)malloc(sizeof(double)*3);
-
-	  // loop over all cells
-	  for(j=0;j<cg->dims[3*c];j++)
-	    for(k=0;k<cg->dims[3*c+1];k++)
-	      for(l=0;l<cg->dims[3*c+2];l++)
-		{
-	    //Q[nq,nZ+2*nf,nY+2*nf,nX+2*nf]--> C++ Cell storage
-      itm = (cg->dims[3*c+1]+2*cg->nf)*(cg->dims[3*c]+2*cg->nf)*(l+cg->nf)
-          + (cg->dims[3*c]+2*cg->nf)*(k+cg->nf) + (j+cg->nf);
-
-      xtm[0] = cg->xlo[3*c]   + (j+0.5)*cg->dx[3*c];
-      xtm[1] = cg->xlo[3*c+1] + (k+0.5)*cg->dx[3*c+1];
-      xtm[2] = cg->xlo[3*c+2] + (l+0.5)*cg->dx[3*c+2];
-
-		  iflag=0;
-
-		    {
-                      //if (intersectCount==1 && myid==0) fprintf(fp,"%lf %lf %lf\n",xtm[0],xtm[1],xtm[2]);
-		      for(jj=0;jj<3;jj++) xd[jj]=0;
-		      for(jj=0;jj<3;jj++)
-			for(kk=0;kk<3;kk++)
-			  xd[jj]+=(xtm[kk]-obb->xc[kk])*obb->vec[jj][kk];
-		      
-		      if (fabs(xd[0]) <= obb->dxc[0] &&
-			  fabs(xd[1]) <= obb->dxc[1] &&
-			  fabs(xd[2]) <= obb->dxc[2])
-			{
-			  iflag++;
-			}
-		    }
-		  
-		  if (iflag > 0) 
-		    {
-		      pmap[cg->proc_id[c]]=1;
-		      dataPtr->next=(INTEGERLIST2 *) malloc(sizeof(INTEGERLIST2));
-		      dataPtr=dataPtr->next;
-          dataPtr->intDataSize=4;
-          dataPtr->realDataSize=4;
-          dataPtr->realData=(double *) malloc(sizeof(double)*dataPtr->realDataSize);
-          dataPtr->intData=(int *) malloc(sizeof(int)*dataPtr->intDataSize);
-		      dataPtr->intData[0]=cg->proc_id[c];
-		      dataPtr->intData[1]=cg->local_id[c];
-	        dataPtr->intData[2]=itm;
-	        dataPtr->intData[3]=0;
-		      nsearch+=1;
-
-          for(kk=0;kk<dataPtr->realDataSize-1;kk++)
-            dataPtr->realData[kk]=xtm[kk];
-
-          dataPtr->realData[dataPtr->realDataSize-1]=vol;
-
-		      dataPtr->next=NULL;
-		    }
-		}
-
-    // loop over all nodes
-    for(j=0;j<cg->dims[3*c]+1;j++)
-      for(k=0;k<cg->dims[3*c+1]+1;k++)
-        for(l=0;l<cg->dims[3*c+2]+1;l++)
-        {
-          // Q[nq,nZ+1+2*nf,nY+1+2*nf,nX+1+2*nf]--> C++ Node storage
-          // indexing starts from number of cells onwards
-          itm = (cg->dims[3*c+1]+1+2*cg->nf)*(cg->dims[3*c]+1+2*cg->nf)*(l+cg->nf)
-              + (cg->dims[3*c]+1+2*cg->nf)*(k+cg->nf) + (j+cg->nf)
-              + cell_count;
-
-          xtm[0] = cg->xlo[3*c]   + j*cg->dx[3*c];
-          xtm[1] = cg->xlo[3*c+1] + k*cg->dx[3*c+1];
-          xtm[2] = cg->xlo[3*c+2] + l*cg->dx[3*c+2];
-
-          iflag=0;
-
-          {
-            //if (intersectCount==1 && myid==0) fprintf(fp,"%lf %lf %lf\n",xtm[0],xtm[1],xtm[2]);
-            for(jj=0;jj<3;jj++) xd[jj]=0;
-            for(jj=0;jj<3;jj++)
-              for(kk=0;kk<3;kk++)
-                xd[jj]+=(xtm[kk]-obb->xc[kk])*obb->vec[jj][kk];
-
-            if (fabs(xd[0]) <= obb->dxc[0] &&
-                fabs(xd[1]) <= obb->dxc[1] &&
-                fabs(xd[2]) <= obb->dxc[2])
-            {
-              iflag++;
-            }
-          }
-
-          if (iflag > 0)
-          {
-            pmap[cg->proc_id[c]]=1;
-            dataPtr->next=(INTEGERLIST2 *) malloc(sizeof(INTEGERLIST2));
-            dataPtr=dataPtr->next;
-            dataPtr->intDataSize=4;
-            dataPtr->realDataSize=4;
-            dataPtr->realData=(double *) malloc(sizeof(double)*dataPtr->realDataSize);
-            dataPtr->intData=(int *) malloc(sizeof(int)*dataPtr->intDataSize);
-            dataPtr->intData[0]=cg->proc_id[c];
-            dataPtr->intData[1]=cg->local_id[c];
-            dataPtr->intData[2]=itm;
-            dataPtr->intData[3]=0;
-            nsearch+=1;
-
-            for(kk=0;kk<dataPtr->realDataSize-1;kk++)
-              dataPtr->realData[kk]=xtm[kk];
-
-            dataPtr->realData[dataPtr->realDataSize-1]=vol;
-
-            dataPtr->next=NULL;
-          }
-        }
-
-	  TIOGA_FREE(xtm);
-	}
+    for(int n=0;n<3;n++)
+    {
+      obcart->dxc[n]=cg->dx[3*c+n]*(cg->dims[3*c+n])*0.5;
+      obcart->xc[n]=cg->xlo[3*c+n]+obcart->dxc[n];
     }
+
+    int intersectCount = 0;
+    if (obbIntersectCheck(obb->vec,obb->xc,obb->dxc,
+      obcart->vec,obcart->xc,obcart->dxc) ||
+        obbIntersectCheck(obcart->vec,obcart->xc,obcart->dxc,
+          obb->vec,obb->xc,obb->dxc))
+    {
+      intersectCount++;
+
+      double* xtm=(double *)malloc(sizeof(double)*3);
+
+      for(int j=0;j<cg->dims[3*c];j++)
+        for(int k=0;k<cg->dims[3*c+1];k++)
+          for(int l=0;l<cg->dims[3*c+2];l++)
+            fillReceptorDataPtr(cg,cell_count,c,j,k,l,pmap,vol,xtm,false,dataPtr);
+
+      for(int j=0;j<cg->dims[3*c]+1;j++)
+        for(int k=0;k<cg->dims[3*c+1]+1;k++)
+          for(int l=0;l<cg->dims[3*c+2]+1;l++)
+            fillReceptorDataPtr(cg,cell_count,c,j,k,l,pmap,vol,xtm,true,dataPtr);
+
+      TIOGA_FREE(xtm);
+    }
+  }
   //
   // create the communication map
   //
-  nsend=0;
-  for(i=0;i<pc->numprocs;i++) if (pmap[i]==1) nsend++;
-  nrecv=nsend;
-  sndMap=(int *)malloc(sizeof(int)*nsend);
-  rcvMap=(int *)malloc(sizeof(int)*nrecv);
-  m=0;
-  for(i=0;i<pc->numprocs;i++)
+  int nsend=0;
+  for(int i=0;i<pc->numprocs;i++) if (pmap[i]==1) nsend++;
+  int nrecv=nsend;
+  int* sndMap=(int *)malloc(sizeof(int)*nsend);
+  int* rcvMap=(int *)malloc(sizeof(int)*nrecv);
+  int m=0;
+  for(int i=0;i<pc->numprocs;i++)
+  {
+    if (pmap[i]==1)
     {
-      if (pmap[i]==1) 
-	{
-	  sndMap[m]=rcvMap[m]=i;
-	  m++;
-	}
+      sndMap[m]=rcvMap[m]=i;
+      m++;
     }
+  }
   pc->setMap(nsend,nrecv,sndMap,rcvMap);
   //
   // if these were already allocated
@@ -250,14 +130,14 @@ void MeshBlock::getCartReceptors(CartGrid *cg,parallelComm *pc)
   rst=(double *) malloc(sizeof(double)*3*nsearch);
   //
   dataPtr=head->next;
-  k=l=m=n=0;
+  int k=0,l=0,n=0,p=0;
   while(dataPtr!=NULL)
   {
-    for(j=0;j<dataPtr->intDataSize-1;j++)
-      isearch[m++]=dataPtr->intData[j];
+    for(int j=0;j<dataPtr->intDataSize-1;j++)
+      isearch[p++]=dataPtr->intData[j];
     tagsearch[k++]=dataPtr->intData[dataPtr->intDataSize-1];
 
-    for(j=0;j<dataPtr->realDataSize-1;j++)
+    for(int j=0;j<dataPtr->realDataSize-1;j++)
       xsearch[n++]=dataPtr->realData[j];
     res_search[l++]=dataPtr->realData[dataPtr->realDataSize-1];
 
@@ -272,4 +152,60 @@ void MeshBlock::getCartReceptors(CartGrid *cg,parallelComm *pc)
   TIOGA_FREE(rcvMap);
 }
 
-  
+void MeshBlock::fillReceptorDataPtr(CartGrid *cg,int cell_count,int c,int j,int k,int l,int* pmap,
+  double vol,double* xtm,bool isNodal,INTEGERLIST2*& dataPtr)
+{
+  int itm = -1;
+  if(isNodal){
+    itm = (cg->dims[3*c+1]+1+2*cg->nf)*(cg->dims[3*c]+1+2*cg->nf)*(l+cg->nf)
+        + (cg->dims[3*c]+1+2*cg->nf)*(k+cg->nf) + (j+cg->nf)
+        + cell_count;
+
+    xtm[0] = cg->xlo[3*c]   + j*cg->dx[3*c];
+    xtm[1] = cg->xlo[3*c+1] + k*cg->dx[3*c+1];
+    xtm[2] = cg->xlo[3*c+2] + l*cg->dx[3*c+2];
+  }
+  else {
+    itm = (cg->dims[3*c+1]+2*cg->nf)*(cg->dims[3*c]+2*cg->nf)*(l+cg->nf)
+        + (cg->dims[3*c]+2*cg->nf)*(k+cg->nf) + (j+cg->nf);
+
+    xtm[0] = cg->xlo[3*c]   + (j+0.5)*cg->dx[3*c];
+    xtm[1] = cg->xlo[3*c+1] + (k+0.5)*cg->dx[3*c+1];
+    xtm[2] = cg->xlo[3*c+2] + (l+0.5)*cg->dx[3*c+2];
+  }
+
+  double xd[3];
+  for(int jj=0;jj<3;jj++) xd[jj]=0;
+  for(int jj=0;jj<3;jj++)
+    for(int kk=0;kk<3;kk++)
+      xd[jj]+=(xtm[kk]-obb->xc[kk])*obb->vec[jj][kk];
+
+  int iflag=0;
+  if (fabs(xd[0]) <= obb->dxc[0] &&
+      fabs(xd[1]) <= obb->dxc[1] &&
+      fabs(xd[2]) <= obb->dxc[2])
+    iflag++;
+
+  if (iflag > 0)
+  {
+    pmap[cg->proc_id[c]]=1;
+    dataPtr->next=(INTEGERLIST2 *) malloc(sizeof(INTEGERLIST2));
+    dataPtr=dataPtr->next;
+    dataPtr->intDataSize=4;
+    dataPtr->realDataSize=4;
+    dataPtr->realData=(double *) malloc(sizeof(double)*dataPtr->realDataSize);
+    dataPtr->intData=(int *) malloc(sizeof(int)*dataPtr->intDataSize);
+    dataPtr->intData[0]=cg->proc_id[c];
+    dataPtr->intData[1]=cg->local_id[c];
+    dataPtr->intData[2]=itm;
+    dataPtr->intData[3]=0;
+    nsearch+=1;
+
+    for(int kk=0;kk<dataPtr->realDataSize-1;kk++)
+      dataPtr->realData[kk]=xtm[kk];
+
+    dataPtr->realData[dataPtr->realDataSize-1]=vol;
+
+    dataPtr->next=NULL;
+  }
+}


### PR DESCRIPTION
This pull request introduces nodes as receptors on background mesh. The function `getCartReceptors` is changed to accommodate nodal receptors in the same data arrays following the cell receptors. Furthermore, certain member variables have been introduced in `CartBlock` to include node and cell numbers. Finally, a couple of checks have been added to make sure the current code works as it is with only cell solution since nodal solution (on background meshes) is not setup to be dealt with in the rest of the code.