### PR TITLE
Create iblank array for nodal variables on Cartesian mesh

### DIFF
--- a/src/CartBlock.h
+++ b/src/CartBlock.h
@@ -35,9 +35,8 @@ class CartBlock
   int local_id;
   int global_id;
   int dims[3],nf,ncell,ncell_nf,nnode,nnode_nf;
-  int d1,d2,d3;
   int myid;
-  int *ibl, *ibln;;
+  int *ibl_cell, *ibl_node;;
   double *qcell, *qnode;
   double xlo[3]; 
   double dx[3];
@@ -47,15 +46,15 @@ class CartBlock
   DONORLIST **donorList;
   void (*donor_frac) (int *,double *,int *,double *);
  public:
-  CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl=NULL;ibln=NULL;qcell=NULL;qnode=NULL;interpListSize=0;donorList=NULL;interpList=NULL;
+  CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl_cell=NULL;ibl_node=NULL;qcell=NULL;qnode=NULL;interpListSize=0;donorList=NULL;interpList=NULL;
     donor_frac=nullptr;};
   ~CartBlock() { clearLists();};
   void registerData(int local_id_in,int global_id_in,int *iblankin,int *iblanknin)
   {
     local_id=local_id_in;
     global_id=global_id_in;
-    ibl=iblankin;
-    ibln=iblanknin;
+    ibl_cell=iblankin;
+    ibl_node=iblanknin;
   };
   void registerSolution(double *qin, bool isnodal) {
     if(isnodal)
@@ -70,7 +69,7 @@ class CartBlock
   void update(double *qval,int index,int nq);
   void getCancellationData(int *cancelledData, int *ncancel);
   void processDonors(HOLEMAP *holemap, int nmesh);
-  void processNodeIblank();
+  void processIblank(HOLEMAP *holemap, int nmesh, bool isNodal);
   void insertInDonorList(int senderid,int index,int meshtagdonor,int remoteid,int remoteblockid,double cellRes);
   void insertInInterpList(int procid,int remoteid,int remoteblockid,double *xtmp);
   void writeCellFile(int bid);

--- a/src/CartBlock.h
+++ b/src/CartBlock.h
@@ -37,7 +37,7 @@ class CartBlock
   int dims[3],nf,ncell,ncell_nf,nnode,nnode_nf;
   int d1,d2,d3;
   int myid;
-  int *ibl;
+  int *ibl, *ibln;;
   double *qcell, *qnode;
   double xlo[3]; 
   double dx[3];
@@ -47,14 +47,15 @@ class CartBlock
   DONORLIST **donorList;
   void (*donor_frac) (int *,double *,int *,double *);
  public:
-  CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl=NULL;qcell=NULL;qnode=NULL;interpListSize=0;donorList=NULL;interpList=NULL;
+  CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl=NULL;ibln=NULL;qcell=NULL;qnode=NULL;interpListSize=0;donorList=NULL;interpList=NULL;
     donor_frac=nullptr;};
   ~CartBlock() { clearLists();};
-  void registerData(int local_id_in,int global_id_in,int *iblankin)
+  void registerData(int local_id_in,int global_id_in,int *iblankin,int *iblanknin)
   {
     local_id=local_id_in;
     global_id=global_id_in;
     ibl=iblankin;
+    ibln=iblanknin;
   };
   void registerSolution(double *qin, bool isnodal) {
     if(isnodal)
@@ -69,6 +70,7 @@ class CartBlock
   void update(double *qval,int index,int nq);
   void getCancellationData(int *cancelledData, int *ncancel);
   void processDonors(HOLEMAP *holemap, int nmesh);
+  void processNodeIblank();
   void insertInDonorList(int senderid,int index,int meshtagdonor,int remoteid,int remoteblockid,double cellRes);
   void insertInInterpList(int procid,int remoteid,int remoteblockid,double *xtmp);
   void writeCellFile(int bid);

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -701,9 +701,9 @@ void tioga::set_amr_patch_count(int npatchesin)
   cb=new CartBlock[ncart];
 }
 
-void tioga::register_amr_local_data(int ipatch,int global_id,int *iblank)
+void tioga::register_amr_local_data(int ipatch,int global_id,int *iblank,int *iblankn)
 {
-  cb[ipatch].registerData(ipatch,global_id,iblank);
+  cb[ipatch].registerData(ipatch,global_id,iblank,iblankn);
 }
 
 void tioga::register_amr_solution(int ipatch,double *q,bool isnodal)

--- a/src/tioga.h
+++ b/src/tioga.h
@@ -249,7 +249,7 @@ class tioga
 
   void register_amr_global_data(int,int *,double *,int);
   void set_amr_patch_count(int);
-  void register_amr_local_data(int, int ,int *);
+  void register_amr_local_data(int, int ,int *, int *);
   void register_amr_solution(int ,double *, bool);
   void exchangeAMRDonors(void);
   void checkComm(void);

--- a/src/tiogaInterface.C
+++ b/src/tiogaInterface.C
@@ -140,9 +140,9 @@ extern "C" {
     tg->set_amr_patch_count(*npatches);
   }
 
-  void tioga_register_amr_local_data_(int *ipatch,int *global_id,int *iblank)
+  void tioga_register_amr_local_data_(int *ipatch,int *global_id,int *iblank,int *iblankn)
   {
-    tg->register_amr_local_data(*ipatch,*global_id,iblank);
+    tg->register_amr_local_data(*ipatch,*global_id,iblank,iblankn);
   }
 
   void tioga_register_amr_solution_(int *ipatch,double *q, bool isnodal)


### PR DESCRIPTION
Based on `iblank_cell` this pull request creates an `iblank` array for nodes. The logic is as follows - If all cells shared by node are field, the node is marked field. If any cell shared by the node is hole, the node is marked hole. Everything else is marked fringe. The interface is changed to accept node iblanks when registering every patch. 

I have also fixed a bug in the computation of `nnode` (not used anywhere currently) as part of this pull request.

Edit: Following the discussion in https://github.com/jsitaraman/tioga/pull/29#discussion_r435960201 
I have updated the pull request (687d927) to evaluate the node iblank based on the `donorList`. Certain variables have been renamed for more clarity. 

Below is the `iblank_cell` and and corresponding `iblank` (averaged to cells using AMReX) for a multi-patch problem

<img width="480" alt="Screen Shot 2020-06-05 at 12 18 02 AM" src="https://user-images.githubusercontent.com/36968394/83843381-14bcb880-a6c2-11ea-8d69-c1e6b09e2a57.png">

<img width="479" alt="Screen Shot 2020-06-05 at 12 18 13 AM" src="https://user-images.githubusercontent.com/36968394/83843388-171f1280-a6c2-11ea-8fba-600a89ad9521.png">
