### PR TITLE
separate inline functions for concatenated and standard node index

### DIFF
--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -335,7 +335,7 @@ void CartBlock::processIblank(HOLEMAP *holemap, int nmesh, bool isNodal)
               if (checkHoleMap(xtmp,holemap[h].nx,holemap[h].sam,holemap[h].extents))
               {
                 int ibindex = isNodal ?
-                    (cart_utils::get_node_index(dims[0],dims[1],dims[2],nf,i,j,k) - ncell_nf) :
+                    cart_utils::get_node_index(dims[0],dims[1],nf,i,j,k) :
                     cart_utils::get_cell_index(dims[0],dims[1],nf,i,j,k);
                 iblank[ibindex]=0;
                 break;
@@ -360,7 +360,7 @@ void CartBlock::processIblank(HOLEMAP *holemap, int nmesh, bool isNodal)
                 if (checkHoleMap(xtmp,holemap[h].nx,holemap[h].sam,holemap[h].extents))
                 {
                   int ibindex = isNodal ?
-                      (cart_utils::get_node_index(dims[0],dims[1],dims[2],nf,i,j,k) - ncell_nf) :
+                      cart_utils::get_node_index(dims[0],dims[1],nf,i,j,k) :
                       cart_utils::get_cell_index(dims[0],dims[1],nf,i,j,k);
                   iblank[ibindex]=0;
                   break;
@@ -380,7 +380,7 @@ void CartBlock::processIblank(HOLEMAP *holemap, int nmesh, bool isNodal)
       {
         idof++;
         int ibindex = isNodal ?
-            (cart_utils::get_node_index(dims[0],dims[1],dims[2],nf,i,j,k) - ncell_nf) :
+            cart_utils::get_node_index(dims[0],dims[1],nf,i,j,k) :
             cart_utils::get_cell_index(dims[0],dims[1],nf,i,j,k);
 
         if (iblank[ibindex]==0)

--- a/src/cartUtils.h
+++ b/src/cartUtils.h
@@ -29,8 +29,15 @@ namespace cart_utils
   }
 
   //Q[nq,nZ+1+2*nf,nY+1+2*nf,nX+1+2*nf]--> C++ node storage
+  inline int get_node_index(int nX,int nY,int nf,int i,int j,int k)
+  {
+    return (nY+1+2*nf)*(nX+1+2*nf)*(k+nf) + (nX+1+2*nf)*(j+nf) + (i+nf);
+  }
+
+  //Q[nq,nZ+1+2*nf,nY+1+2*nf,nX+1+2*nf]--> C++ node storage
+  // for arrays with both node and cell indices,
   // node index is assumed to follow cell index
-  inline int get_node_index(int nX,int nY,int nZ,int nf,int i,int j,int k)
+  inline int get_concatenated_node_index(int nX,int nY,int nZ,int nf,int i,int j,int k)
   {
     return (nY+1+2*nf)*(nX+1+2*nf)*(k+nf) + (nX+1+2*nf)*(j+nf) + (i+nf)
         + (nX+2*nf)*(nY+2*nf)*(nZ+2*nf);

--- a/src/getCartReceptors.C
+++ b/src/getCartReceptors.C
@@ -158,8 +158,8 @@ void MeshBlock::fillReceptorDataPtr(CartGrid *cg,int cell_count,int c,int j,int 
 {
   int itm = -1;
   if(isNodal){
-    itm = cart_utils::get_node_index(cg->dims[3*c],cg->dims[3*c+1],cg->dims[3*c+2],
-      cg->nf,j,k,l);
+    itm = cart_utils::get_concatenated_node_index(
+      cg->dims[3*c],cg->dims[3*c+1],cg->dims[3*c+2],cg->nf,j,k,l);
 
     xtm[0] = cg->xlo[3*c]   + j*cg->dx[3*c];
     xtm[1] = cg->xlo[3*c+1] + k*cg->dx[3*c+1];


### PR DESCRIPTION
Seeing as how the `iblank` array requires computation of the node index in a patch vs `getCartReceptors` which required node index of a patch concatenated to the cell indices, this pull request introduces an additional function allowing to distinguish between the two.  