### PR TITLE
Registering host/device data from applications

### DIFF
--- a/src/CartBlock.C
+++ b/src/CartBlock.C
@@ -17,12 +17,14 @@
 // You should have received a copy of the GNU Lesser General Public
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+#include <stdexcept>
+#include "TiogaMeshInfo.h"
 #include "codetypes.h"
 #include "CartBlock.h"
 #include "CartGrid.h"
 #include "cartUtils.h"
 #include "linCartInterp.h"
-#include <stdexcept>
+
 extern "C" {
   void deallocateLinkList(DONORLIST *temp);
   void deallocateLinkList2(INTEGERLIST *temp);
@@ -31,6 +33,25 @@ extern "C" {
   void insertInList(DONORLIST **donorList,DONORLIST *temp1);
   int checkHoleMap(double *x,int *nx,int *sam,double *extents);
 }
+
+void CartBlock::registerData(int lid, TIOGA::AMRMeshInfo* minfo)
+{
+  local_id = lid;
+  global_id = minfo->global_idmap.hptr[lid];
+  ibl_cell = minfo->iblank_cell.hptr[lid];
+  ibl_node = minfo->iblank_node.hptr[lid];
+
+  registerSolution(lid, minfo);
+}
+
+void CartBlock::registerSolution(int lid, TIOGA::AMRMeshInfo* minfo)
+{
+  nvar_cell = minfo->nvar_cell;
+  nvar_node = minfo->nvar_node;
+  qcell = minfo->qcell.hptr[lid];
+  qnode = minfo->qnode.hptr[lid];
+}
+
 void CartBlock::getInterpolatedData(int *nints,int *nreals,int **intData,
 				    double **realData)
 {

--- a/src/CartBlock.h
+++ b/src/CartBlock.h
@@ -29,6 +29,10 @@ struct INTERPLIST2;
 struct DONORLIST;
 struct HOLEMAP;
 
+namespace TIOGA {
+struct AMRMeshInfo;
+}
+
 class CartGrid;
 class CartBlock
 {
@@ -51,6 +55,10 @@ class CartBlock
   CartBlock() { global_id=0;dims[0]=dims[1]=dims[2]=0;ibl_cell=NULL;ibl_node=NULL;qcell=NULL;qnode=NULL;interpListSize=0;donorList=NULL;interpList=NULL;
     donor_frac=nullptr;nvar_cell=0;nvar_node=0;};
   ~CartBlock() { clearLists();};
+
+  void registerData(int lid, TIOGA::AMRMeshInfo* minfo);
+  void registerSolution(int lid, TIOGA::AMRMeshInfo* minfo);
+
   void registerData(int local_id_in,int global_id_in,int *iblankin,int *iblanknin)
   {
     local_id=local_id_in;

--- a/src/CartGrid.C
+++ b/src/CartGrid.C
@@ -38,6 +38,8 @@ CartGrid::~CartGrid()
   }
   if (lcount) TIOGA_FREE(lcount);
   if (dxlvl) TIOGA_FREE(dxlvl);
+
+  if (m_info_device != nullptr) TIOGA_FREE_DEVICE(m_info_device);
 };
 
 void CartGrid::registerData(TIOGA::AMRMeshInfo* minfo)

--- a/src/CartGrid.C
+++ b/src/CartGrid.C
@@ -20,6 +20,23 @@
 # include "codetypes.h"
 # include "CartGrid.h"
 
+CartGrid::~CartGrid()
+{
+  if (own_data_ptrs) {
+    if (global_id) TIOGA_FREE(global_id);
+    if (level_num) TIOGA_FREE(level_num);
+    if (proc_id) TIOGA_FREE(proc_id);
+    if (local_id) TIOGA_FREE(local_id);
+    if (ilo) TIOGA_FREE(ilo);
+    if (ihi) TIOGA_FREE(ihi);
+    if (dims) TIOGA_FREE(dims);
+    if (xlo) TIOGA_FREE(xlo);
+    if (dx) TIOGA_FREE(dx);
+  }
+  if (lcount) TIOGA_FREE(lcount);
+  if (dxlvl) TIOGA_FREE(dxlvl);
+};
+
 void CartGrid::registerData(int nfin,int *idata,double *rdata,int ngridsin)
 {
   int i,i3,i6,iloc,n;

--- a/src/CartGrid.h
+++ b/src/CartGrid.h
@@ -22,7 +22,11 @@
 #define CARTGRID_H
 
 #include <cstdlib>
-#include "TiogaMeshInfo.h"
+
+namespace TIOGA
+{
+struct AMRMeshInfo;
+}
 
 class CartGrid
 {
@@ -35,6 +39,9 @@ class CartGrid
   bool own_data_ptrs{true};
 
  public :
+  TIOGA::AMRMeshInfo* m_info{nullptr};
+  TIOGA::AMRMeshInfo* m_info_device{nullptr};
+
   int *global_id{nullptr};
   int *level_num{nullptr};
   int *proc_id{nullptr};
@@ -42,8 +49,8 @@ class CartGrid
   int *ilo{nullptr};
   int *ihi{nullptr};
   int *dims{nullptr};
-  int myid;
-  int nf;
+  int myid{0};
+  int nf{0};
   double *xlo{nullptr};
   double *dx{nullptr};
   int ngrids{0};
@@ -51,6 +58,8 @@ class CartGrid
 
   CartGrid() = default;
   ~CartGrid();
+
+  void registerData(TIOGA::AMRMeshInfo* m_info);
   void registerData(int nf,int *idata,double *rdata,int ngridsin);
   void preprocess(void);     
   void search(double *x,int *donorid,int nsearch);

--- a/src/CartGrid.h
+++ b/src/CartGrid.h
@@ -22,6 +22,7 @@
 #define CARTGRID_H
 
 #include <cstdlib>
+#include "TiogaMeshInfo.h"
 
 class CartGrid
 {
@@ -31,37 +32,25 @@ class CartGrid
   int *lcount{nullptr};
   int maxlevel;
 
+  bool own_data_ptrs{true};
+
  public :
-  int *global_id;
-  int *level_num;
-  int *proc_id;
-  int *local_id;
-  int *ilo;
-  int *ihi;
-  int *dims;
+  int *global_id{nullptr};
+  int *level_num{nullptr};
+  int *proc_id{nullptr};
+  int *local_id{nullptr};
+  int *ilo{nullptr};
+  int *ihi{nullptr};
+  int *dims{nullptr};
   int myid;
   int nf;
-  double *xlo;
-  double *dx;
-  int ngrids;
+  double *xlo{nullptr};
+  double *dx{nullptr};
+  int ngrids{0};
   void (*donor_frac) (int *,double *,int *,double *) = nullptr;
-   
-  CartGrid() { ngrids=0;global_id=NULL;level_num=NULL;local_id=NULL;
-    proc_id=NULL;local_id=NULL;ilo=NULL;ihi=NULL;dims=NULL;
-               xlo=NULL;dx=NULL;dxlvl=NULL;lcount=NULL;donor_frac=nullptr;};
-  ~CartGrid() { 
-    if (global_id) free(global_id);
-    if (level_num) free(level_num);
-    if (proc_id) free(proc_id);
-    if (local_id) free(local_id);
-    if (ilo) free(ilo);
-    if (ihi) free(ihi);
-    if (dims) free(dims);
-    if (xlo) free(xlo);
-    if (dx) free(dx);
-    if (lcount) free(lcount);
-    if (dxlvl) free(dxlvl);
-  };
+
+  CartGrid() = default;
+  ~CartGrid();
   void registerData(int nf,int *idata,double *rdata,int ngridsin);
   void preprocess(void);     
   void search(double *x,int *donorid,int nsearch);

--- a/src/MeshBlock.C
+++ b/src/MeshBlock.C
@@ -71,6 +71,44 @@ void MeshBlock::setData(int btag,int nnodesi,double *xyzi, int *ibli,int nwbci, 
 #endif
 }
 
+void MeshBlock::setData(TIOGA::MeshBlockInfo* minfo)
+{
+  m_info = minfo;
+
+  // Populate legacy data
+  meshtag = m_info->meshtag;
+  nnodes = m_info->num_nodes;
+  x = m_info->xyz.hptr;
+  iblank = m_info->iblank_node.hptr;
+  iblank_cell = m_info->iblank_cell.hptr;
+  nwbc = m_info->wall_ids.sz;
+  nobc = m_info->overset_ids.sz;
+  wbcnode = m_info->wall_ids.hptr;
+  obcnode = m_info->overset_ids.hptr;
+
+  ntypes = m_info->num_vert_per_elem.sz;
+  nv = m_info->num_vert_per_elem.hptr;
+  nc = m_info->num_cells_per_elem.hptr;
+
+  for (int i=0; i < TIOGA::MeshBlockInfo::max_vertex_types; ++i) {
+    vconn_ptrs[i] = m_info->vertex_conn[i].hptr;
+  }
+  vconn = &vconn_ptrs[0];
+
+  cellGID = m_info->cell_gid.hptr;
+  nodeGID = m_info->node_gid.hptr;
+
+  userSpecifiedNodeRes = m_info->node_res.hptr;
+  userSpecifiedCellRes = m_info->cell_res.hptr;
+
+  interptype = m_info->qtype;
+
+#ifdef TIOGA_HAS_NODEGID
+  if (nodeGID == nullptr)
+    throw std::runtime_error("#tioga: global IDs for nodes not provided");
+#endif
+}
+
 void MeshBlock::preprocess(void)
 {
   int i;

--- a/src/MeshBlock.h
+++ b/src/MeshBlock.h
@@ -26,6 +26,8 @@
 #include <assert.h>
 #include "codetypes.h"
 #include "ADT.h"
+#include "TiogaMeshInfo.h"
+
 // forward declare to instantiate one of the methods
 class parallelComm;
 class CartGrid;
@@ -39,6 +41,7 @@ class CartGrid;
 class MeshBlock
 {
  private:
+  TIOGA::MeshBlockInfo* m_info{nullptr};
   int nnodes;  /** < number of grid nodes */
   int ncells;  /** < total number of cells */
   int ntypes;  /** < number of different types of cells */
@@ -146,6 +149,8 @@ class MeshBlock
   INTERPLIST *interpListCart; 
   int* receptorIdCart;
 
+  int* vconn_ptrs[TIOGA::MeshBlockInfo::max_vertex_types];
+
   //
   // call back functions to use p4est to search
   // its own internal data
@@ -190,8 +195,10 @@ class MeshBlock
   void writeGridFile(int bid);
 
   void writeFlowFile(int bid,double *q,int nvar,int type);
-  
-  void setData(int btag,int nnodesi,double *xyzi, int *ibli,int nwbci, int nobci, 
+
+  void setData(TIOGA::MeshBlockInfo* minfo);
+
+  void setData(int btag,int nnodesi,double *xyzi, int *ibli,int nwbci, int nobci,
 	       int *wbcnodei,int *obcnodei,
                int ntypesi, int *nvi, int *nci, int **vconni,
                uint64_t* cell_gid=NULL, uint64_t* node_gid=NULL);
@@ -357,6 +364,9 @@ class MeshBlock
 
   int num_var() const { return nvar; }
   int& num_var() { return nvar; }
+
+  const TIOGA::MeshBlockInfo* mesh_info() const { return m_info; }
+  TIOGA::MeshBlockInfo* mesh_info() { return m_info; }
 
   void set_interptype(int type) {
     interptype = type;

--- a/src/MeshBlock.h
+++ b/src/MeshBlock.h
@@ -41,7 +41,19 @@ class CartGrid;
 class MeshBlock
 {
  private:
+  /** Mesh block info provided by the application code
+   *
+   *  This is a non-owning pointer whose lifetime is controlled by the
+   *  application.
+   */
   TIOGA::MeshBlockInfo* m_info{nullptr};
+
+  /** Device copy of the mesh block info registered by the application code
+   *
+   *  This pointer is owned by MeshBlock
+   */
+  TIOGA::MeshBlockInfo* m_info_device{nullptr};
+
   int nnodes;  /** < number of grid nodes */
   int ncells;  /** < total number of cells */
   int ntypes;  /** < number of different types of cells */
@@ -367,6 +379,9 @@ class MeshBlock
 
   const TIOGA::MeshBlockInfo* mesh_info() const { return m_info; }
   TIOGA::MeshBlockInfo* mesh_info() { return m_info; }
+
+  const TIOGA::MeshBlockInfo* d_mesh_info() const { return m_info_device; }
+  TIOGA::MeshBlockInfo* d_mesh_info() { return m_info_device; }
 
   void set_interptype(int type) {
     interptype = type;

--- a/src/TiogaMeshInfo.h
+++ b/src/TiogaMeshInfo.h
@@ -63,18 +63,23 @@ struct AMRMeshInfo
     TiogaView<int> local_id;
     TiogaView<int> ilow;
     TiogaView<int> ihigh;
+    TiogaView<int> dims;
     TiogaView<double> xlo;
     TiogaView<double> dx;
 
     // Patch data for all patches belonging to this MPI rank
     // [ngrids_local]
     TiogaView<int> global_idmap;
-    TiogaView<int> iblank_node;
-    TiogaView<int> iblank_cell;
-    TiogaView<double> qcell;
-    TiogaView<double> qnode;
+    TiogaView<int*> iblank_node;
+    TiogaView<int*> iblank_cell;
+    TiogaView<double*> qcell;
+    TiogaView<double*> qnode;
 
     int num_ghost{0};
+    int ngrids_global{0};
+    int ngrids_local{0};
+    int nvar_cell{0};
+    int nvar_node{0};
 };
 
 } // namespace TIOGA

--- a/src/TiogaMeshInfo.h
+++ b/src/TiogaMeshInfo.h
@@ -1,0 +1,82 @@
+#ifndef TIOGAMESHINFO_H
+#define TIOGAMESHINFO_H
+
+#include <cstdlib>
+#include <cstdint>
+
+namespace TIOGA {
+
+template <typename T>
+struct TiogaView
+{
+    T* hptr{nullptr};
+    T* dptr{nullptr};
+
+    size_t sz{0};
+    bool host_modified{false};
+    bool device_modified{false};
+};
+
+/** Representation of an unstructured mesh
+ */
+struct MeshBlockInfo
+{
+    static constexpr int max_vertex_types = 4;
+    using GlobalIDType = uint64_t;
+
+    enum QVarType {
+        ROW = 0,
+        COL
+    };
+
+    TiogaView<int> wall_ids;
+    TiogaView<int> overset_ids;
+    TiogaView<int> num_vert_per_elem;
+    TiogaView<int> num_cells_per_elem;
+    TiogaView<int> vertex_conn[max_vertex_types];
+
+    TiogaView<double> xyz;
+    TiogaView<int> iblank_node;
+    TiogaView<int> iblank_cell;
+    TiogaView<double> qnode;
+
+    TiogaView<GlobalIDType> cell_gid;
+    TiogaView<GlobalIDType> node_gid;
+
+    TiogaView<double> node_res;
+    TiogaView<double> cell_res;
+
+    int meshtag{0};
+    int num_nodes{0};
+    int num_vars{0};
+
+    QVarType qtype{ROW};
+};
+
+/** Representation of an AMReX mesh
+ */
+struct AMRMeshInfo
+{
+    // Patch info common to all MPI ranks [ngrids_global]
+    TiogaView<int> level;
+    TiogaView<int> mpi_rank;
+    TiogaView<int> local_id;
+    TiogaView<int> ilow;
+    TiogaView<int> ihigh;
+    TiogaView<double> xlo;
+    TiogaView<double> dx;
+
+    // Patch data for all patches belonging to this MPI rank
+    // [ngrids_local]
+    TiogaView<int> global_idmap;
+    TiogaView<int> iblank_node;
+    TiogaView<int> iblank_cell;
+    TiogaView<double> qcell;
+    TiogaView<double> qnode;
+
+    int num_ghost{0};
+};
+
+} // namespace TIOGA
+
+#endif /* TIOGAMESHINFO_H */

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -760,6 +760,29 @@ tioga::~tioga()
   if (myid==0) printf("#tioga :successfully cleared all the memory accessed\n");
 };
 
+void tioga::register_amr_grid(TIOGA::AMRMeshInfo* minfo)
+{
+  if (cg) delete [] cg;
+  if (cb) delete [] cb;
+
+  cg = new CartGrid[1];
+  ncart = minfo->ngrids_local;
+  cb = new CartBlock[ncart];
+  cg->registerData(minfo);
+
+  for (int ic = 0; ic < ncart; ++ic) {
+    cb[ic].registerData(ic, minfo);
+  }
+}
+
+void tioga::register_amr_solution()
+{
+  auto* minfo = cg->m_info;
+  for (int ic = 0; ic < ncart; ++ic) {
+    cb[ic].registerSolution(ic, minfo);
+  }
+}
+
 void tioga::register_amr_global_data(int nf,int *idata,double *rdata,int ngridsin)
 {
   if (cg) delete [] cg;

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -82,6 +82,29 @@ void tioga::registerGridData(int btag,int nnodes,double *xyz,int *ibl, int nwbc,
   mb->myid = myid;
 }
 
+void tioga::register_unstructured_grid(TIOGA::MeshBlockInfo *minfo)
+{
+
+  int iblk;
+
+  const int btag = minfo->meshtag;
+  auto idxit = tag_iblk_map.find(btag);
+  if (idxit == tag_iblk_map.end()) {
+    mtags.push_back(btag);
+    mytag.push_back(btag);
+    mblocks.push_back(std::unique_ptr<MeshBlock>(new MeshBlock));
+    nblocks = mblocks.size();
+    iblk = nblocks - 1;
+    tag_iblk_map[btag] = iblk;
+  } else {
+    iblk = idxit->second;
+  }
+
+  auto& mb = mblocks[iblk];
+  mb->setData(minfo);
+  mb->myid = myid;
+}
+
 void tioga::registerSolution(int btag,double *q)
 {
   auto idxit=tag_iblk_map.find(btag);
@@ -96,6 +119,15 @@ void tioga::register_unstructured_solution(int btag,double *q,int nvar,int inter
   qblock[iblk]=q;
   mblocks[iblk]->num_var() = nvar;
   mblocks[iblk]->set_interptype(interptype);
+}
+
+void tioga::register_unstructured_solution()
+{
+  for (int iblk = 0; iblk < mblocks.size(); ++iblk) {
+    const auto* minfo = mblocks[iblk]->mesh_info();
+    qblock[iblk] = minfo->qnode.hptr;
+    mblocks[iblk]->num_var() = minfo->num_vars;
+  }
 }
 
 void tioga::profile(void)

--- a/src/tioga.h
+++ b/src/tioga.h
@@ -126,6 +126,9 @@ class tioga
 
   void register_unstructured_solution(int btag,double *q,int nvar,int interptype);
 
+  void register_unstructured_grid(TIOGA::MeshBlockInfo* minfo);
+  void register_unstructured_solution();
+
   void profile(void);
 
   void exchangeBoxes(void);

--- a/src/tioga.h
+++ b/src/tioga.h
@@ -129,6 +129,9 @@ class tioga
   void register_unstructured_grid(TIOGA::MeshBlockInfo* minfo);
   void register_unstructured_solution();
 
+  void register_amr_grid(TIOGA::AMRMeshInfo* minfo);
+  void register_amr_solution();
+
   void profile(void);
 
   void exchangeBoxes(void);

--- a/src/tioga_nogpu.h
+++ b/src/tioga_nogpu.h
@@ -2,6 +2,7 @@
 #define TIOGA_NOGPU_H
 
 #include <cstdlib>
+#include <cstring>
 
 #define TIOGA_GPU_DEVICE
 #define TIOGA_GPU_GLOBAL


### PR DESCRIPTION
This PR introduces data structures for registering host/device data for MeshBlock and CartGrid/Block 

- [x] *Info* data structs for MeshBlock and CartGrid/Block
- [x] MeshBlock
  - [x] Create interface to register data using the new *info* struct objects
  - [x] Hook up legacy class instances for testing new API using existing code and to allow gradual transition
  - [x] Update Tioga class to register MeshBlock using new interface
- [x] CartGrid/Block
  - [x] Create interface to register data using the new *info* struct objects
  - [x] Hook up legacy class instances for testing new API using existing code and to allow gradual transition
  - [x] Update Tioga class to register MeshBlock using new interface
