### PR TITLE
Generalize AMR patch support in TIOGA

### DIFF
--- a/src/CartGrid.C
+++ b/src/CartGrid.C
@@ -22,6 +22,8 @@
 # include "codetypes.h"
 # include "CartGrid.h"
 
+#include <cassert>
+#include <numeric>
 
 CartGrid::~CartGrid()
 {
@@ -36,6 +38,20 @@ CartGrid::~CartGrid()
     if (xlo) TIOGA_FREE(xlo);
     if (dx) TIOGA_FREE(dx);
   }
+
+  if (own_amr_mesh_info && (m_info != nullptr)) {
+    TIOGA_FREE_DEVICE(m_info->level.dptr);
+    TIOGA_FREE_DEVICE(m_info->mpi_rank.dptr);
+    TIOGA_FREE_DEVICE(m_info->local_id.dptr);
+    TIOGA_FREE_DEVICE(m_info->ilow.dptr);
+    TIOGA_FREE_DEVICE(m_info->ihigh.dptr);
+    TIOGA_FREE_DEVICE(m_info->dims.dptr);
+    TIOGA_FREE_DEVICE(m_info->xlo.dptr);
+    TIOGA_FREE_DEVICE(m_info->dx.dptr);
+
+    TIOGA_FREE(m_info);
+  }
+
   if (lcount) TIOGA_FREE(lcount);
   if (dxlvl) TIOGA_FREE(dxlvl);
 
@@ -45,6 +61,7 @@ CartGrid::~CartGrid()
 void CartGrid::registerData(TIOGA::AMRMeshInfo* minfo)
 {
   own_data_ptrs = false;
+  own_amr_mesh_info = false;
   m_info = minfo;
   ngrids = minfo->ngrids_global;
   global_id = nullptr; // unused
@@ -108,6 +125,9 @@ void CartGrid::registerData(int nfin,int *idata,double *rdata,int ngridsin)
                                    local_id[i],dx[i3],dx[i3+1],dx[i3+2]);
     }
    if (myid==0) fclose(fp);
+
+   // Create AMRMeshInfo object so that it can be accessed on device in future
+   create_mesh_info();
 };
 
 //
@@ -186,4 +206,58 @@ void CartGrid::search(double *x,int *donorid,int npts)
     if (donorid[i]==-1) printf("%d %f %f %f\n",myid,x[3*i],x[3*i+1],x[3*i+2]);
   }
  //printf("CartGrid::search Processor %d located %d of %d points\n",myid,dcount,npts);
+}
+
+namespace {
+
+template<typename T>
+inline void create_view(TIOGA::TiogaView<T> tv, T* sptr, int sz)
+{
+  tv.sz = sz;
+  tv.hptr = sptr;
+  tv.dptr = TIOGA::gpu::push_to_device<T>(tv.hptr, sizeof(T) * sz);
+}
+
+}
+
+/** Create AMRMeshInfo objects that can be accessed on host and device
+ *
+ *  This method serves two purposes: 1. It ensures that a valid AMRMeshInfo
+ *  object exists even when using the legacy TIOGA API; and, 2. For simulations
+ *  where AMR solver does not span all MPI processes visible to TIOGA, this
+ *  creates a valid AMRMeshInfo object so that the unstructured block can query
+ *  patch information to perform searches. See tioga::preprocess_amr_data for
+ *  more information.
+ */
+void CartGrid::create_mesh_info()
+{
+  assert(proc_id != nullptr);
+
+  if (m_info == nullptr) m_info = new TIOGA::AMRMeshInfo;
+  m_info->ngrids_global = ngrids;
+  m_info->num_ghost = nf;
+  create_view(m_info->level, level_num, ngrids);
+  create_view(m_info->mpi_rank, proc_id, ngrids);
+  create_view(m_info->local_id, local_id, ngrids);
+  create_view(m_info->ilow, ilo, ngrids * 3);
+  create_view(m_info->ihigh, ihi, ngrids * 3);
+  create_view(m_info->dims, dims, ngrids * 3);
+  create_view(m_info->xlo, xlo, ngrids * 3);
+  create_view(m_info->dx, dx, ngrids * 3);
+
+  int iproc = myid;
+  int nplocal = std::accumulate(
+    proc_id, proc_id + ngrids, 0,
+    [iproc](int x, int y) -> int { return x + ((iproc == y) ? 1 : 0); });
+
+  m_info->ngrids_local = nplocal;
+
+  if (m_info_device == nullptr) {
+    m_info_device = TIOGA::gpu::allocate_on_device<TIOGA::AMRMeshInfo>(
+      sizeof(TIOGA::AMRMeshInfo));
+  }
+  TIOGA::gpu::copy_to_device(m_info_device, m_info, sizeof(TIOGA::AMRMeshInfo));
+
+  own_data_ptrs = true;
+  own_amr_mesh_info = true;
 }

--- a/src/CartGrid.C
+++ b/src/CartGrid.C
@@ -49,7 +49,7 @@ CartGrid::~CartGrid()
     TIOGA_FREE_DEVICE(m_info->xlo.dptr);
     TIOGA_FREE_DEVICE(m_info->dx.dptr);
 
-    TIOGA_FREE(m_info);
+    delete m_info;
   }
 
   if (lcount) TIOGA_FREE(lcount);

--- a/src/CartGrid.h
+++ b/src/CartGrid.h
@@ -37,6 +37,7 @@ class CartGrid
   int maxlevel;
 
   bool own_data_ptrs{true};
+  bool own_amr_mesh_info{false};
 
  public :
   TIOGA::AMRMeshInfo* m_info{nullptr};
@@ -65,6 +66,8 @@ class CartGrid
   void search(double *x,int *donorid,int nsearch);
   void setcallback(void (*f1)(int *,double *,int *,double *)) 
   {   donor_frac=f1;  }
+
+  void create_mesh_info();
 };
 
 #endif /* CARTGRID_H */

--- a/src/tioga.h
+++ b/src/tioga.h
@@ -137,6 +137,12 @@ class tioga
   void register_amr_grid(TIOGA::AMRMeshInfo* minfo);
   void register_amr_solution();
 
+  /** Synchronize AMR patch information on all processes
+   *
+   *  \param root Root process from which data is broadcast to other processes
+   */
+  void preprocess_amr_data(int root = 0);
+
   void profile(void);
 
   void exchangeBoxes(void);


### PR DESCRIPTION
Update CartGrid interface to support two objectives:

Ensure that there is a valid AMRMeshInfo object on host and device even when
using the legacy AMR mesh registration interface.

Introduce a new `tioga::preprocess_amr_data` that will ensure that a valid
CartGrid instance exists on all MPI ranks visible to TIOGA even if the AMR
solver is running on a subset of MPI processes.