### PR TITLE
Fake GPU pathways on CPU build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ option(TIOGA_ENABLE_TIMERS "Track timing information for TIOGA (default: off)" O
 option(TIOGA_OUTPUT_STATS "Output statistics for TIOGA holecutting (default: off)" OFF)
 option(TIOGA_ENABLE_CUDA "Enable CUDA support (default: off)" OFF)
 option(TIOGA_ENABLE_HIP "Enable AMD HIP support (default: off)" OFF)
+option(TIOGA_FAKE_GPU "Fake GPU pathways for testing (default: off)" OFF)
 
 # CUDA specific options
 set(TIOGA_CUDA_SM "70" CACHE STRING "CUDA arch option")

--- a/driver/gpu_test.C
+++ b/driver/gpu_test.C
@@ -7,7 +7,7 @@ void print_gpu_info()
 {
     namespace gpu = TIOGA::gpu;
     std::cout << "BEGIN TEST print_gpu_info" << std::endl;
-#ifdef TIOGA_HAS_GPU
+#if defined(TIOGA_HAS_GPU) && !defined(TIOGA_FAKE_GPU)
 #if defined(CUDA_VERSION)
     std::cout << "CUDA configuration: "
               << "CUDA_VERSION: " << CUDA_VERSION

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,11 @@ if (TIOGA_ENABLE_HIP)
     $<$<COMPILE_LANGUAGE:CXX>:-x hip>)
 endif()
 
+if (TIOGA_FAKE_GPU)
+  target_compile_definitions(tioga PUBLIC
+    TIOGA_HAS_GPU TIOGA_FAKE_GPU)
+endif()
+
 # Enable position independent code
 set_target_properties(tioga PROPERTIES POSITION_INDEPENDENT_CODE ON)
 

--- a/src/gpu_global_functions.h
+++ b/src/gpu_global_functions.h
@@ -3,7 +3,7 @@
 TIOGA_GPU_GLOBAL
 void g_reset_iblanks(int *iblank, int nnodes)
 {
-#ifdef TIOGA_HAS_GPU
+#if defined(TIOGA_HAS_GPU) && !defined(TIOGA_FAKE_GPU)
   int idx = blockIdx.x * blockDim.x + threadIdx.x;
   if (idx < nnodes) {
 #else
@@ -20,7 +20,7 @@ void g_adt_search(double *x, int **vconn,int *nc, int *nv, int ntypes,
              int *elementList, int *donorId, double *xsearch, 
 	     int ndim, int nelem, int nsearch)
 {
-#ifdef TIOGA_HAS_GPU
+#if defined(TIOGA_HAS_GPU) && !defined(TIOGA_FAKE_GPU)
   int idx = blockIdx.x*blockDim.x + threadIdx.x;
   if (idx < nsearch) {
 #else

--- a/src/tioga_gpu.h
+++ b/src/tioga_gpu.h
@@ -12,7 +12,7 @@
 namespace TIOGA {
 namespace gpu {
 
-#if defined(TIOGA_HAS_GPU)
+#if defined(TIOGA_HAS_GPU) && !defined(TIOGA_FAKE_GPU)
 #define TIOGA_GPU_CHECK_ERROR(call) {                                             \
         TIOGA::gpu::gpuError_t gpu_ierr = (call);                                 \
         if (TIOGA::gpu::gpuSuccess != gpu_ierr) {                                 \

--- a/src/tioga_nogpu.h
+++ b/src/tioga_nogpu.h
@@ -18,6 +18,9 @@ constexpr gpuError_t gpuSuccess = 0;
 inline gpuError_t gpuGetLastError() { return gpuSuccess; }
 inline const char* gpuGetErrorString(gpuError_t err) { return "Success"; }
 
+#define TIOGA_GPU_LAUNCH_FUNC(func, blocks, threads, sharedmem, stream, ...) \
+  func(__VA_ARGS__);
+
 template <typename T>
 inline T* allocate_on_device(const size_t size)
 {


### PR DESCRIPTION
Adds CMake option `-DTIOGA_FAKE_GPU=ON` to enable GPU code pathways on GPU
builds for debugging/testing.