### PR TITLE
remove now redundant set data function in dMeshBlock

### DIFF
--- a/src/MeshBlock.C
+++ b/src/MeshBlock.C
@@ -120,8 +120,6 @@ void MeshBlock::setData(TIOGA::MeshBlockInfo* minfo)
   TIOGA::gpu::copy_to_device(m_info_device, m_info, sizeof(TIOGA::MeshBlockInfo));
 #ifdef TIOGA_HAS_GPU
   if (!dMB) dMB.reset(new TIOGA::dMeshBlock);
-  //dMB->setData(m_info_device);
-  //dMB->setData(m_info);
   dMB->setMinfo(m_info_device,myid);
 #endif
 

--- a/src/dMeshBlock.C
+++ b/src/dMeshBlock.C
@@ -11,63 +11,6 @@ namespace TIOGA {
     myid=myid_in;
   }
 
-  void dMeshBlock::setData(TIOGA::MeshBlockInfo* m_info)
-  {
-    // Populate legacy data
-#if defined(TIOGA_HAS_GPU) 
- #if defined(TIOGA_FAKE_GPU)
-    meshtag = m_info->meshtag;
-    nnodes = m_info->num_nodes;
-    x = m_info->xyz.dptr;
-    iblank = m_info->iblank_node.dptr;
-    iblank_cell = m_info->iblank_cell.dptr;
-    nwbc = m_info->wall_ids.sz;
-    nobc = m_info->overset_ids.sz;
-    wbcnode = m_info->wall_ids.dptr;
-    obcnode = m_info->overset_ids.dptr;
-    
-    ntypes = m_info->num_vert_per_elem.sz;
-    nv = m_info->num_vert_per_elem.dptr;
-    nc = m_info->num_cells_per_elem.dptr;
-    
-    ncells=0;
-    for(int i=0;i<ntypes;i++) ncells+=nc[i];
-    
-    for (int i=0; i < TIOGA::MeshBlockInfo::max_vertex_types; i++) {
-      vconn_ptrs[i] = m_info->vertex_conn[i].dptr;
-    }
-    vconn=&vconn_ptrs[0];
- #else
-    meshtag = m_info->meshtag;
-    nnodes = m_info->num_nodes;
-    x = m_info->xyz.hptr;
-    iblank = m_info->iblank_node.dptr;
-    iblank_cell = m_info->iblank_cell.dptr;
-    nwbc = m_info->wall_ids.sz;
-    nobc = m_info->overset_ids.sz;
-    wbcnode = m_info->wall_ids.dptr;
-    obcnode = m_info->overset_ids.dptr;
-    
-    ntypes = m_info->num_vert_per_elem.sz;
-    nv = m_info->num_vert_per_elem.dptr;
-    nc = m_info->num_cells_per_elem.dptr;
-//    printf("ntypes=%d\n",ntypes);
-//    for(int i=0;i<ntypes;i++) printf("nv[i],nc[i]=%d %d\n",nv[i],nc[i]);  
-    ncells=0;
-    for(int i=0;i<ntypes;i++) ncells+=m_info->num_cells_per_elem.hptr[i];
-    
-    for (int i=0; i < TIOGA::MeshBlockInfo::max_vertex_types; i++) {
-      vconn_ptrs[i] = m_info->vertex_conn[i].dptr;
-      //if (i==0) ndc4= m_info->vertex_conn[i].hptr;
-      //if (i==1) ndc5= m_info->vertex_conn[i].hptr;
-      //if (i==2) ndc6= m_info->vertex_conn[i].hptr;
-      //if (i==0) ndc8= m_info->vertex_conn[i].hptr;
-    }
-    vconn=&vconn_ptrs[0];
-  #endif
-#endif
-  }
-
   void dMeshBlock::resetIblanks() {
 #ifdef TIOGA_HAS_GPU
     int n_blocks = nnodes/block_size + (nnodes%block_size == 0 ? 0:1);

--- a/src/dMeshBlock.h
+++ b/src/dMeshBlock.h
@@ -30,7 +30,6 @@ public:
   ~dMeshBlock() {};
 
   void setMinfo( TIOGA::MeshBlockInfo* m_info_in, int myid_in);
-  void setData( TIOGA::MeshBlockInfo* m_info_device);
   void resetIblanks();
   void search(ADT *adt,int *elementList, double *xsearch, int *donorId, int nsearch);
 


### PR DESCRIPTION
We were using `setData` initially, but with change in interface and use of `setMinfo`, the former is now redundant.