### PR TITLE
Fixed issue 54 by moving MPI options to target_compile_options

### DIFF
--- a/driver/CMakeLists.txt
+++ b/driver/CMakeLists.txt
@@ -6,7 +6,7 @@ set(TIOGA_EXE_SOURCES
   )
 
 add_library(tiogadriver ${TIOGA_EXE_SOURCES})
-target_compile_definitions(tiogadriver PUBLIC ${MPI_Fortran_COMPILE_FLAGS})
+target_compile_options(tiogadriver PUBLIC ${MPI_Fortran_COMPILE_FLAGS})
 target_include_directories(tiogadriver PUBLIC ${MPI_Fortran_INCLUDE_PATH})
 target_link_libraries(tiogadriver
   tioga ${MPI_Fortran_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/gridGen/CMakeLists.txt
+++ b/gridGen/CMakeLists.txt
@@ -8,7 +8,7 @@ set(GRIDGEN_SOURCES
 
 add_executable(buildGrid ${GRIDGEN_SOURCES})
 
-target_compile_definitions(buildGrid PUBLIC ${MPI_Fortran_COMPILE_FLAGS})
+target_compile_options(buildGrid PUBLIC ${MPI_Fortran_COMPILE_FLAGS})
 target_include_directories(buildGrid PUBLIC ${MPI_Fortran_INCLUDE_PATH})
 target_link_libraries(buildGrid
   tioga ${MPI_Fortran_LIBRARIES} ${CMAKE_DL_LIBS})


### PR DESCRIPTION
I tested with Spack by creating two patches and adding them to the tioga package.py file with "spack edit tioga".