### PR TITLE
remove now redundant device-related functionalities in MeshBlock and dMeshBlock

### DIFF
--- a/src/MeshBlock.C
+++ b/src/MeshBlock.C
@@ -113,16 +113,9 @@ void MeshBlock::setData(TIOGA::MeshBlockInfo* minfo)
     throw std::runtime_error("#tioga: global IDs for nodes not provided");
 #endif
 
-  if (m_info_device == nullptr) {
-    m_info_device = TIOGA::gpu::allocate_on_device<TIOGA::MeshBlockInfo>(
-      sizeof(TIOGA::MeshBlockInfo));
-  }
-  TIOGA::gpu::copy_to_device(m_info_device, m_info, sizeof(TIOGA::MeshBlockInfo));
 #ifdef TIOGA_HAS_GPU
   if (!dMB) dMB.reset(new TIOGA::dMeshBlock);
-  //dMB->setData(m_info_device);
-  //dMB->setData(m_info);
-  dMB->setMinfo(m_info_device,myid);
+  dMB->setMinfo(m_info,myid);
 #endif
 
 }
@@ -1305,8 +1298,6 @@ MeshBlock::~MeshBlock()
   if (mapmask) TIOGA_FREE(mapmask);
   if (uindx) TIOGA_FREE(uindx);
   if (invmap) TIOGA_FREE(invmap);
-
-  if (m_info_device) TIOGA_FREE_DEVICE(m_info_device);
 
   // need to add code here for other objects as and
   // when they become part of MeshBlock object  

--- a/src/MeshBlock.h
+++ b/src/MeshBlock.h
@@ -49,12 +49,6 @@ class MeshBlock
    */
   TIOGA::MeshBlockInfo* m_info{nullptr};
 
-  /** Device copy of the mesh block info registered by the application code
-   *
-   *  This pointer is owned by MeshBlock
-   */
-  TIOGA::MeshBlockInfo* m_info_device{nullptr};
-
   std::unique_ptr<TIOGA::dMeshBlock> dMB;
   
   //TIOGA::dMeshBlock *dMB; /** device instance of mesh block with device specific methods */
@@ -385,9 +379,6 @@ class MeshBlock
 
   const TIOGA::MeshBlockInfo* mesh_info() const { return m_info; }
   TIOGA::MeshBlockInfo* mesh_info() { return m_info; }
-
-  const TIOGA::MeshBlockInfo* d_mesh_info() const { return m_info_device; }
-  TIOGA::MeshBlockInfo* d_mesh_info() { return m_info_device; }
 
   void set_interptype(int type) {
     interptype = type;

--- a/src/dMeshBlock.C
+++ b/src/dMeshBlock.C
@@ -7,74 +7,28 @@ namespace TIOGA {
 
   void dMeshBlock::setMinfo(TIOGA::MeshBlockInfo *m_info_in, int myid_in)
   {
-    m_info_device=m_info_in;
+    if (m_info_device == nullptr) {
+      m_info_device = TIOGA::gpu::allocate_on_device<TIOGA::MeshBlockInfo>(
+        sizeof(TIOGA::MeshBlockInfo));
+    }
+    TIOGA::gpu::copy_to_device(m_info_device, m_info_in, sizeof(TIOGA::MeshBlockInfo));
+
     myid=myid_in;
   }
 
-  void dMeshBlock::setData(TIOGA::MeshBlockInfo* m_info)
+  // destructor that deallocates all the
+  // the dynamic objects inside
+  //
+  dMeshBlock::~dMeshBlock()
   {
-    // Populate legacy data
-#if defined(TIOGA_HAS_GPU) 
- #if defined(TIOGA_FAKE_GPU)
-    meshtag = m_info->meshtag;
-    nnodes = m_info->num_nodes;
-    x = m_info->xyz.dptr;
-    iblank = m_info->iblank_node.dptr;
-    iblank_cell = m_info->iblank_cell.dptr;
-    nwbc = m_info->wall_ids.sz;
-    nobc = m_info->overset_ids.sz;
-    wbcnode = m_info->wall_ids.dptr;
-    obcnode = m_info->overset_ids.dptr;
-    
-    ntypes = m_info->num_vert_per_elem.sz;
-    nv = m_info->num_vert_per_elem.dptr;
-    nc = m_info->num_cells_per_elem.dptr;
-    
-    ncells=0;
-    for(int i=0;i<ntypes;i++) ncells+=nc[i];
-    
-    for (int i=0; i < TIOGA::MeshBlockInfo::max_vertex_types; i++) {
-      vconn_ptrs[i] = m_info->vertex_conn[i].dptr;
-    }
-    vconn=&vconn_ptrs[0];
- #else
-    meshtag = m_info->meshtag;
-    nnodes = m_info->num_nodes;
-    x = m_info->xyz.hptr;
-    iblank = m_info->iblank_node.dptr;
-    iblank_cell = m_info->iblank_cell.dptr;
-    nwbc = m_info->wall_ids.sz;
-    nobc = m_info->overset_ids.sz;
-    wbcnode = m_info->wall_ids.dptr;
-    obcnode = m_info->overset_ids.dptr;
-    
-    ntypes = m_info->num_vert_per_elem.sz;
-    nv = m_info->num_vert_per_elem.dptr;
-    nc = m_info->num_cells_per_elem.dptr;
-//    printf("ntypes=%d\n",ntypes);
-//    for(int i=0;i<ntypes;i++) printf("nv[i],nc[i]=%d %d\n",nv[i],nc[i]);  
-    ncells=0;
-    for(int i=0;i<ntypes;i++) ncells+=m_info->num_cells_per_elem.hptr[i];
-    
-    for (int i=0; i < TIOGA::MeshBlockInfo::max_vertex_types; i++) {
-      vconn_ptrs[i] = m_info->vertex_conn[i].dptr;
-      //if (i==0) ndc4= m_info->vertex_conn[i].hptr;
-      //if (i==1) ndc5= m_info->vertex_conn[i].hptr;
-      //if (i==2) ndc6= m_info->vertex_conn[i].hptr;
-      //if (i==0) ndc8= m_info->vertex_conn[i].hptr;
-    }
-    vconn=&vconn_ptrs[0];
-  #endif
-#endif
-  }
+    if (m_info_device) TIOGA_FREE_DEVICE(m_info_device);
+  };
 
   void dMeshBlock::resetIblanks() {
 #ifdef TIOGA_HAS_GPU
     int n_blocks = nnodes/block_size + (nnodes%block_size == 0 ? 0:1);
-//    TIOGA_GPU_LAUNCH_FUNC(g_reset_iblanks, n_blocks, block_size, 0, 0, iblank, nnodes);
     TIOGA_GPU_LAUNCH_FUNC(g_reset_iblanks, n_blocks, block_size, 0, 0, m_info_device);
     TIOGA::gpu::synchronize();
-    //g_reset_iblanks<<<n_blocks,block_size>>>(iblank,nnodes);
 #endif
   }
 

--- a/src/dMeshBlock.h
+++ b/src/dMeshBlock.h
@@ -27,10 +27,9 @@ public:
 
   dMeshBlock() {}
 
-  ~dMeshBlock() {};
+  ~dMeshBlock();
 
   void setMinfo( TIOGA::MeshBlockInfo* m_info_in, int myid_in);
-  void setData( TIOGA::MeshBlockInfo* m_info_device);
   void resetIblanks();
   void search(ADT *adt,int *elementList, double *xsearch, int *donorId, int nsearch);
 


### PR DESCRIPTION
This pull request revises upon #53 to not only remove the obsolete set data functions, but also removes m_info_device from MeshBlock. It is sufficient for only dMeshBlock to own m_info_device since all MB gpu kernels are launched in dMeshBlock.